### PR TITLE
feat: (ECDSA) Active auth signature validation

### DIFF
--- a/activeauth/active_auth_test.go
+++ b/activeauth/active_auth_test.go
@@ -300,26 +300,6 @@ func TestDoInternalAuthenticateCardDeadErr(t *testing.T) {
 	}
 }
 
-func TestEcdsaValidateActiveAuthSignature(t *testing.T) {
-	var doc *document.Document = &document.Document{}
-
-	// Test case from actual Dutch passport.
-	var rndIfd = "cfacd60f82c6607b"
-	var aaSignature = "caad3981647f105534174faf66b218f44aee8e30a51fb9498311fcd5350356a1c42dae26dd17395e053374d2d84f37819c1e2fdb22ce87023cc7b3c74d8de1ccbd74cfe0c6de6094c7df12fe40a5abf4"
-	var dg15bytes []byte = utils.HexToBytes("6f820179308201753082011d06072a8648ce3d020130820110020101303406072a8648ce3d0101022900d35e472036bc4fb7e13c785ed201e065f98fcfa6f6f40def4f92b9ec7893ec28fcd412b1f1b32e27305404283ee30b568fbab0f883ccebd46d3f3bb8a2a73513f5eb79da66190eb085ffa9f492f375a97d860eb40428520883949dfdbc42d3ad198640688a6fe13f41349554b49acc31dccd884539816f5eb4ac8fb1f1a604510443bd7e9afb53d8b85289bcc48ee5bfe6f20137d10a087eb6e7871e2a10a599c710af8d0d39e2061114fdd05545ec1cc8ab4093247f77275e0743ffed117182eaa9c77877aaac6ac7d35245d1692e8ee1022900d35e472036bc4fb7e13c785ed201e065f98fcfa5b68f12a32d482ec7ee8658e98691555b44c59311020101035200047049a1dcb7a9132ffe9d76bd34f19052fbaa4694741c883eabab369d38aa7d7365e893c917b16289766d5afa55ccfabb29570115625aade54a576db2f68ebe96e94771277c123c797805dca1af05ba39")
-
-	err := doc.NewDG(15, dg15bytes)
-	if err != nil {
-		t.Errorf("Unexpected error: %s", err)
-	}
-
-	var activeAuth *ActiveAuth = NewActiveAuth(nil, doc)
-	err = activeAuth.ValidateActiveAuthSignature(utils.HexToBytes(aaSignature), utils.HexToBytes(rndIfd))
-	if err != nil {
-		t.Errorf("ValidateActiveAuthSignature failed: %s", err)
-	}
-}
-
 // Build DG15 from an EC public key: DG15 = 0x6F || len || SPKI
 func makeDG15FromECPublicKey(pub *ecdsa.PublicKey) ([]byte, error) {
 	spki, err := x509.MarshalPKIXPublicKey(pub)

--- a/cryptoutils/crypto_utils.go
+++ b/cryptoutils/crypto_utils.go
@@ -7,6 +7,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/des"
+	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/md5"
 	"crypto/rand"
@@ -296,6 +297,21 @@ func RsaDecryptWithPublicKey(ciphertext []byte, publicKey RsaPublicKey) []byte {
 	c := new(big.Int).Exp(m, e, publicKey.N)
 
 	return c.Bytes()
+}
+
+func CryptoHashFromEcPubKey(pub *ecdsa.PublicKey) crypto.Hash {
+	nbits := pub.Params().N.BitLen()
+	switch {
+	case nbits >= 512:
+		return crypto.SHA512
+	case nbits >= 384:
+		return crypto.SHA384
+	case nbits >= 256:
+		return crypto.SHA256
+	default:
+		// 224-bit curves or smaller
+		return crypto.SHA224
+	}
 }
 
 // support for P192 (secp-192r1) which is required by some countries but not supported by the go libraries

--- a/cryptoutils/crypto_utils_test.go
+++ b/cryptoutils/crypto_utils_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto"
 	"crypto/cipher"
 	"crypto/elliptic"
+	"crypto/ecdsa"
 	"encoding/asn1"
 	"math/big"
 	"testing"
@@ -674,5 +675,25 @@ func TestEllipticP192WithEcDh(t *testing.T) {
 
 	if !ecPoint1.Equal(*ecPoint2) {
 		t.Errorf("P192-with-ECDH EcPoint mismatch following ECDH (ecPoint1:%s, ecPoint2:%s)", ecPoint1.String(), ecPoint2.String())
+	}
+}
+
+func TestCryptoHashFromEcPubKey(t *testing.T) {
+	cases := []struct {
+		name   string
+		curve  elliptic.Curve
+		want   crypto.Hash
+	}{
+		{"P-224", elliptic.P224(), crypto.SHA224},
+		{"P-256", elliptic.P256(), crypto.SHA256},
+		{"P-384", elliptic.P384(), crypto.SHA384},
+		{"P-521", elliptic.P521(), crypto.SHA512},
+	}
+	for _, tc := range cases {
+		pub := &ecdsa.PublicKey{Curve: tc.curve, X: tc.curve.Params().Gx, Y: tc.curve.Params().Gy}
+		got := CryptoHashFromEcPubKey(pub)
+		if got != tc.want {
+			t.Errorf("curve %s: got %v, want %v", tc.name, got, tc.want)
+		}
 	}
 }


### PR DESCRIPTION
Extracted the validation of `active authentication signatures` to a separate function so that it can be reused for `active auth signatures` derived outside of the library.

Also implemented the validation of passports with an elliptic curve based pub key inside DG15. This is tested with Dutch passports, which use brainpool p320 public keys.

I still need to add sample brainpool curves. 

Resolves #57 