### PR TITLE
fix: correct RSA signature verification for authentication

### DIFF
--- a/activeauth/active_auth.go
+++ b/activeauth/active_auth.go
@@ -178,7 +178,18 @@ func (activeAuth *ActiveAuth) ValidateActiveAuthSignature(intAuthRspBytes []byte
 			// S = rapdu-data
 			s := intAuthRspBytes
 
+			// Add context before decryption for debugging
+			keyWidth := (pubKey.N.BitLen() + 7) / 8
+			errContext = fmt.Sprintf("sigLen:%d,keyWidth:%d,sig:%x", len(s), keyWidth, s)
+
 			f := cryptoutils.RsaDecryptWithPublicKey(s, *pubKey)
+
+			// Log decrypted data for debugging
+			slog.Debug("ValidateActiveAuthSignature", "f_len", len(f), "f", utils.BytesToHex(f))
+
+			// ISO/IEC 9796-2: Strip leading zero bytes before decoding
+			// The meaningful signature data starts at 0x6A, any leading zeros are padding
+			f = utils.TrimLeadingZeroBytes(f)
 
 			m1, d, hashAlg, err := decodeF(f)
 			if err != nil {


### PR DESCRIPTION
## Problem Analysis
We experienced two issues one with `Active Authentication` on Australian passports and one with `Passive Authentication` on Polish passports.

### Active Authentication Error
```
ERROR: failed to verify passport: active authentication failed: 
failed to validate active authentication signature: 
(DoActiveAuth) decodeF error: (decodeF) must start with 0x6A
```

**Root Cause**: After PR #104 fixed `RsaDecryptWithPublicKey` to preserve leading zeros (matching RSA key width), the decrypted signature now includes padding zeros. The ISO/IEC 9796-2 format expects data to start with `0x6A`, but leading zeros from RSA padding were being included.

**Impact**: Active Authentication fails on Australian passports where RSA decryption produces leading zeros.

### Passive Authentication Error
```
Error: failed to verify passport: passive authentication failed: unexpected error: [PassiveAuth] unable to verify SignedData (SOD): [Verify] si.Verify(idx:0) error: [Verify] VerifySignature error: [VerifySignature] Invalid RSA signature (sig:01ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff003031300d060960864801650304020105000420f765b948417be2166bbb57b9b7dae06cc47e0e303a7c5adb9efccaa375b362ff, digest:3bbef7a77d95d105a93e5c4490b1eb932f57ec31789a08602abe8ce992aa49859ffd014b43cbcb012cf365deaa560ad4b07af9d0cf6039cd00cebe384f43f9ef)
```

**Root Cause**: The verification used `bytes.HasSuffix(decrypted, digest)` which only checked if decrypted signature ended with the digest. This approach:
- Didn't validate PKCS#1 v1.5 padding structure (`00 01 FF...FF 00`)
- Didn't validate DigestInfo ASN.1 structure
- Didn't verify algorithm OID matches expected hash

**Impact**: Passive Authentication fails on real Polish passports.

## Solutions

### Active Authentication Fix
Strip leading zeros before decoding ISO/IEC 9796-2 format:
```go
f = utils.TrimLeadingZeroBytes(f)
m1, d, hashAlg, err := decodeF(f)
```

### Passive Authentication Fix
Replace manual verification with standard library's proper PKCS#1 v1.5 validation:
```go
err = rsa.VerifyPKCS1v15(rsaPubKey, hashAlg, digest, sig)
```

This correctly validates the complete DigestInfo structure.

## Testing
- Added regression test with detailed comments
- Fixes confirmed against ICAO 9303 specifications