### PR TITLE
fix(activeauth):support DER-encoded ECDSA signatures for AA

### DIFF
--- a/activeauth/active_auth.go
+++ b/activeauth/active_auth.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"crypto"
 	"crypto/ecdsa"
+	"encoding/asn1"
 	"fmt"
 	"log/slog"
 	"math/big"
@@ -19,6 +20,50 @@ import (
 
 // TODO - does this currently make any use of DG14.ActiveAuthInfos? (eg NL passport)
 //			- not a big deal, as we currently drive AA primarily from DG15
+
+// ecdsaSignature represents an ASN.1/DER encoded ECDSA signature
+type ecdsaSignature struct {
+	R, S *big.Int
+}
+
+// parseEcdsaSignaturePlain parses an ECDSA signature in plain r||s format
+// (TR-03110 "ecdsa-plain" style, used by ICAO 9303 passports)
+func parseEcdsaSignaturePlain(sigBytes []byte) (r, s *big.Int, err error) {
+	if len(sigBytes) == 0 {
+		return nil, nil, fmt.Errorf("empty signature")
+	}
+
+	if len(sigBytes)%2 != 0 {
+		return nil, nil, fmt.Errorf("plain signature must have even length, got %d", len(sigBytes))
+	}
+
+	half := len(sigBytes) / 2
+	r = new(big.Int).SetBytes(sigBytes[:half])
+	s = new(big.Int).SetBytes(sigBytes[half:])
+
+	return r, s, nil
+}
+
+// parseEcdsaSignatureDER parses an ECDSA signature in ASN.1/DER format
+// (X9.62 standard, used by some national ID cards like Portuguese Cartão de Cidadão)
+func parseEcdsaSignatureDER(sigBytes []byte) (r, s *big.Int, err error) {
+	if len(sigBytes) == 0 {
+		return nil, nil, fmt.Errorf("empty signature")
+	}
+
+	var sig ecdsaSignature
+	rest, err := asn1.Unmarshal(sigBytes, &sig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse DER-encoded ECDSA signature: %w", err)
+	}
+	if len(rest) > 0 {
+		slog.Debug("parseEcdsaSignatureDER", "trailing_bytes", len(rest))
+	}
+	if sig.R == nil || sig.S == nil {
+		return nil, nil, fmt.Errorf("DER-encoded signature has nil R or S")
+	}
+	return sig.R, sig.S, nil
+}
 
 type ActiveAuth struct {
 	randomBytesFn cryptoutils.RandomBytesFn
@@ -234,6 +279,10 @@ func ValidateActiveAuthSignature(dg15 *document.DG15, intAuthRspBytes, rndIfd []
 				ECDSA key in use, SHALL be used. Only SHA-224, SHA-256, SHA-384 or SHA-512 are supported as hash functions.
 				RIPEMD-160 and SHA-1 SHALL NOT be used.
 				The message M to be signed is the nonce RND.IFD provided by the Inspection System.
+
+				Note: While ICAO 9303 specifies plain r||s format, some national ID cards (e.g., Portuguese Cartão de Cidadão)
+				use ASN.1/DER encoded signatures (X9.62 standard). This implementation tries plain format first, then falls
+				back to DER if plain fails and the signature starts with 0x30 (SEQUENCE tag).
 			*/
 			curve, ecPoint, err := subPubKeyInfo.EcCurveAndPubKey()
 			if err != nil {
@@ -246,21 +295,36 @@ func ValidateActiveAuthSignature(dg15 *document.DG15, intAuthRspBytes, rndIfd []
 				Y:     ecPoint.Y,
 			}
 
-			var r, s big.Int
-			// Plain concatenation r||s (TR-03110 "ecdsa-plain" style)
-			if len(intAuthRspBytes)%2 != 0 {
-				return result, fmt.Errorf("(ValidateActiveAuthSignature) Unexpected plain signature length: %d (Context:%s)", len(intAuthRspBytes), errContext)
-			}
-			half := len(intAuthRspBytes) / 2
-			r.SetBytes(intAuthRspBytes[:half])
-			s.SetBytes(intAuthRspBytes[half:])
-
 			var alg = cryptoutils.CryptoHashFromEcPubKey(pub)
 			var hash = cryptoutils.CryptoHash(alg, rndIfd)
-			var verified = ecdsa.Verify(pub, hash, &r, &s)
-			if !verified {
-				return result, fmt.Errorf("(ValidateActiveAuthSignature) AA signature did not verify with hash: %s for the provided nonce", alg.String())
+
+			// Try plain r||s format first (TR-03110, used by most passports)
+			r, s, plainErr := parseEcdsaSignaturePlain(intAuthRspBytes)
+			if plainErr == nil {
+				slog.Debug("ValidateActiveAuthSignature", "format", "plain r||s")
+				if ecdsa.Verify(pub, hash, r, s) {
+					// Success with plain format
+					result.Success = true
+					return result, nil
+				}
 			}
+
+			// If plain format failed or didn't verify, and signature starts with 0x30, try DER format
+			if len(intAuthRspBytes) > 0 && intAuthRspBytes[0] == 0x30 {
+				slog.Debug("ValidateActiveAuthSignature", "format", "trying DER/ASN.1 fallback")
+				r, s, derErr := parseEcdsaSignatureDER(intAuthRspBytes)
+				if derErr == nil {
+					if ecdsa.Verify(pub, hash, r, s) {
+						// Success with DER format
+						slog.Debug("ValidateActiveAuthSignature", "format", "DER/ASN.1 succeeded")
+						result.Success = true
+						return result, nil
+					}
+				}
+			}
+
+			// Both formats failed
+			return result, fmt.Errorf("(ValidateActiveAuthSignature) AA signature did not verify with hash: %s for the provided nonce (tried plain r||s and DER formats)", alg.String())
 		}
 	default:
 		return result, fmt.Errorf("(ValidateActiveAuthSignature) unsupported SubjectPublicKeyInfo (OID:%s) (Context:%s)", subPubKeyInfo.Algorithm.Algorithm.String(), errContext)

--- a/activeauth/active_auth_test.go
+++ b/activeauth/active_auth_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
+	"encoding/asn1"
 	"math/big"
 	"reflect"
 	"testing"
@@ -355,6 +356,13 @@ func leftPad(b []byte, size int) []byte {
 	return out
 }
 
+// DER/ASN.1 encoded signature (X9.62 format, used by some national ID cards)
+func encodeDERSignature(r, s *big.Int) ([]byte, error) {
+	return asn1.Marshal(struct {
+		R, S *big.Int
+	}{r, s})
+}
+
 func TestEcdsaValidateActiveAuthSignatureAllCurves(t *testing.T) {
 	type testCase struct {
 		name             string
@@ -457,4 +465,213 @@ func TestEcdsaValidateActiveAuthSignatureAllCurves(t *testing.T) {
 
 		}
 	}
+}
+
+// TestEcdsaValidateActiveAuthSignatureDERFormat tests that DER-encoded ECDSA signatures
+// are correctly validated. This format is used by some national ID cards (e.g., Portuguese
+// Cartão de Cidadão) instead of the plain r||s format specified in ICAO 9303.
+func TestEcdsaValidateActiveAuthSignatureDERFormat(t *testing.T) {
+	type testCase struct {
+		name             string
+		dg15bytes        []byte
+		rndIfd           []byte
+		signature        []byte
+		expectErr        bool
+		expResultSuccess bool
+	}
+
+	var cases []testCase
+
+	// Test DER-encoded signatures for various curves
+	curves := []struct {
+		name string
+		ec   elliptic.Curve
+	}{
+		{"P-256", elliptic.P256()},
+		{"P-384", elliptic.P384()},
+		{"P-521", elliptic.P521()},
+	}
+
+	for _, c := range curves {
+		priv, err := ecdsa.GenerateKey(c.ec, rand.Reader)
+		if err != nil {
+			t.Fatalf("keygen %s: %v", c.name, err)
+		}
+		dg15, err := makeDG15FromECPublicKey(&priv.PublicKey)
+		if err != nil {
+			t.Fatalf("DG15 build %s: %v", c.name, err)
+		}
+
+		rndIfd := cryptoutils.RandomBytes(8)
+		hashAlg := cryptoutils.CryptoHashFromEcPubKey(&priv.PublicKey)
+		hash := cryptoutils.CryptoHash(hashAlg, rndIfd)
+
+		r, s, err := ecdsa.Sign(rand.Reader, priv, hash)
+		if err != nil {
+			t.Fatalf("sign %s: %v", c.name, err)
+		}
+
+		// Create DER-encoded signature
+		derSig, err := encodeDERSignature(r, s)
+		if err != nil {
+			t.Fatalf("DER encode %s: %v", c.name, err)
+		}
+
+		// Positive: valid DER-encoded signature
+		cases = append(cases, testCase{
+			name:             c.name + " DER valid",
+			dg15bytes:        dg15,
+			rndIfd:           rndIfd,
+			signature:        derSig,
+			expectErr:        false,
+			expResultSuccess: true,
+		})
+
+		// Negative: DER-encoded signature with wrong nonce
+		wrongRnd := cryptoutils.RandomBytes(8)
+		cases = append(cases, testCase{
+			name:             c.name + " DER wrong nonce",
+			dg15bytes:        dg15,
+			rndIfd:           wrongRnd,
+			signature:        derSig,
+			expectErr:        true,
+			expResultSuccess: false,
+		})
+
+		// Negative: corrupted DER signature
+		badDer := make([]byte, len(derSig))
+		copy(badDer, derSig)
+		// Corrupt the r value (skip the header bytes)
+		if len(badDer) > 10 {
+			badDer[8] ^= 0xFF
+		}
+		cases = append(cases, testCase{
+			name:             c.name + " DER corrupted",
+			dg15bytes:        dg15,
+			rndIfd:           rndIfd,
+			signature:        badDer,
+			expectErr:        true,
+			expResultSuccess: false,
+		})
+	}
+
+	for _, tc := range cases {
+		var err error
+		var dg15 *document.DG15
+
+		dg15, err = document.NewDG15(tc.dg15bytes)
+		if err != nil {
+			t.Errorf("%s: NewDG15 error: %v", tc.name, err)
+			continue
+		}
+
+		var aaResult *document.ActiveAuthResult
+
+		aaResult, err = ValidateActiveAuthSignature(dg15, tc.signature, tc.rndIfd)
+		if tc.expectErr && err == nil {
+			t.Errorf("%s: expected error, got nil", tc.name)
+		}
+		if !tc.expectErr && err != nil {
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+		}
+		if aaResult.Success != tc.expResultSuccess {
+			t.Errorf("%s: Result 'success' differs to expected [act] %t [exp] %t", tc.name, aaResult.Success, tc.expResultSuccess)
+		}
+	}
+}
+
+// TestParseEcdsaSignaturePlain tests the parseEcdsaSignaturePlain function
+func TestParseEcdsaSignaturePlain(t *testing.T) {
+	curve := elliptic.P256()
+	curveByteLen := (curve.Params().BitSize + 7) / 8
+
+	// Generate a valid signature
+	priv, err := ecdsa.GenerateKey(curve, rand.Reader)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+
+	hash := cryptoutils.CryptoHash(crypto.SHA256, []byte("test data"))
+	r, s, err := ecdsa.Sign(rand.Reader, priv, hash)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	t.Run("valid plain format", func(t *testing.T) {
+		plainSig := concatRSFixed(curve, r, s)
+		parsedR, parsedS, err := parseEcdsaSignaturePlain(plainSig)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if parsedR.Cmp(r) != 0 {
+			t.Errorf("R mismatch: got %v, want %v", parsedR, r)
+		}
+		if parsedS.Cmp(s) != 0 {
+			t.Errorf("S mismatch: got %v, want %v", parsedS, s)
+		}
+	})
+
+	t.Run("empty signature", func(t *testing.T) {
+		_, _, err := parseEcdsaSignaturePlain([]byte{})
+		if err == nil {
+			t.Error("expected error for empty signature")
+		}
+	})
+
+	t.Run("odd length rejected", func(t *testing.T) {
+		oddSig := make([]byte, curveByteLen*2+1)
+		_, _, err := parseEcdsaSignaturePlain(oddSig)
+		if err == nil {
+			t.Error("expected error for odd-length signature")
+		}
+	})
+}
+
+// TestParseEcdsaSignatureDER tests the parseEcdsaSignatureDER function
+func TestParseEcdsaSignatureDER(t *testing.T) {
+	curve := elliptic.P256()
+
+	// Generate a valid signature
+	priv, err := ecdsa.GenerateKey(curve, rand.Reader)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+
+	hash := cryptoutils.CryptoHash(crypto.SHA256, []byte("test data"))
+	r, s, err := ecdsa.Sign(rand.Reader, priv, hash)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	t.Run("valid DER format", func(t *testing.T) {
+		derSig, err := encodeDERSignature(r, s)
+		if err != nil {
+			t.Fatalf("DER encode: %v", err)
+		}
+		parsedR, parsedS, err := parseEcdsaSignatureDER(derSig)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if parsedR.Cmp(r) != 0 {
+			t.Errorf("R mismatch: got %v, want %v", parsedR, r)
+		}
+		if parsedS.Cmp(s) != 0 {
+			t.Errorf("S mismatch: got %v, want %v", parsedS, s)
+		}
+	})
+
+	t.Run("empty signature", func(t *testing.T) {
+		_, _, err := parseEcdsaSignatureDER([]byte{})
+		if err == nil {
+			t.Error("expected error for empty signature")
+		}
+	})
+
+	t.Run("invalid DER", func(t *testing.T) {
+		invalidDer := []byte{0x30, 0x05, 0x01, 0x02, 0x03}
+		_, _, err := parseEcdsaSignatureDER(invalidDer)
+		if err == nil {
+			t.Error("expected error for invalid DER")
+		}
+	})
 }


### PR DESCRIPTION
Some national ID cards (e.g., Portuguese Cartão de Cidadão) use ASN.1/DER encoded ECDSA signatures (X9.62 standard) instead of the plain r||s format specified in ICAO 9303 / TR-03110.

This change adds fallback support for DER-encoded signatures:
1. Try plain r||s format first (backwards compatible)
2. If plain fails and signature starts with 0x30, try DER format
3. Return error only if both formats fail

Fixes #187 