### PR TITLE
fix(tlv): ParseLength panics on 32-bit builds when long-form length e…

### DIFF
--- a/tlv/length.go
+++ b/tlv/length.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"math"
 
 	"github.com/gmrtd/gmrtd/utils"
 )
@@ -38,7 +39,11 @@ func ParseLength(buf *bytes.Buffer) (length TlvLength, err error) {
 		}
 		uint32bytes := make([]byte, 4)
 		copy(uint32bytes[4-byteLen:], bytes)
-		length = TlvLength(binary.BigEndian.Uint32(uint32bytes))
+		rawLen := binary.BigEndian.Uint32(uint32bytes)
+		if uint64(rawLen) > uint64(math.MaxInt) {
+			return 0, fmt.Errorf("[ParseLength] Length exceeds platform int size (length:%d)", rawLen)
+		}
+		length = TlvLength(rawLen)
 	} else {
 		return 0, fmt.Errorf("[ParseLength] Unsupported length (b1:%02x) (remBytes:%x)", b1, buf.Bytes())
 	}

--- a/tlv/length_test.go
+++ b/tlv/length_test.go
@@ -79,6 +79,24 @@ func TestGetLengthBadLengthErr(t *testing.T) {
 	}
 }
 
+func TestParseLengthMaxUint32NoPanic(t *testing.T) {
+	// 0x84 prefix + 0xFFFFFFFF = max uint32 length
+	// On 32-bit platforms this must return an error (exceeds math.MaxInt).
+	// On 64-bit platforms this is valid. Either way it must not panic.
+	var buf *bytes.Buffer = bytes.NewBuffer(utils.HexToBytes("84FFFFFFFF"))
+
+	length, err := ParseLength(buf)
+
+	// math.MaxInt differs by platform, so just verify no panic and consistent result
+	if err != nil {
+		// expected on 32-bit
+		return
+	}
+	if length != TlvLength(0xFFFFFFFF) {
+		t.Errorf("Expected length 0xFFFFFFFF, got %x", length)
+	}
+}
+
 func TestEncodeLengthBadLengthErr(t *testing.T) {
 	defer func() { _ = recover() }()
 


### PR DESCRIPTION
…xceeds MaxInt

Fixes #337 