### PR TITLE
feat(chipauth): capture CA evidence and add offline VerifyEvidence

### DIFF
--- a/chipauth/chip_auth.go
+++ b/chipauth/chip_auth.go
@@ -2,10 +2,12 @@
 package chipauth
 
 import (
+	"bytes"
 	"crypto/elliptic"
 	"encoding/asn1"
 	"fmt"
 	"log/slog"
+	"math/big"
 
 	"github.com/gmrtd/gmrtd/cryptoutils"
 	"github.com/gmrtd/gmrtd/document"
@@ -35,6 +37,12 @@ type ChipAuthParams struct {
 	AlgInfo     *CaAlgorithmInfo
 	PubKeyInfo  *document.ChipAuthenticationPublicKeyInfo
 	AlgInferred bool
+}
+
+type caEcdhEvidence struct {
+	termPri    []byte
+	termPubKey []byte
+	smRapdu    []byte
 }
 
 func selectChipAuthParams(doc *document.Document) (*ChipAuthParams, error) {
@@ -77,13 +85,21 @@ func (chipAuth *ChipAuth) DoChipAuth() (result *document.ChipAuthResult, err err
 		return result, fmt.Errorf("[DoChipAuth] selectChipAuthParams error: %w", err)
 	}
 
-	err = chipAuth.executeCA(params)
+	evidence, err := chipAuth.executeCA(params)
 	if err != nil {
 		return result, fmt.Errorf("[DoChipAuth] executeCA error: %w", err)
 	}
 
 	// update result to indicate success
 	result.Success = true
+
+	if evidence != nil {
+		result.Evidence = &document.ChipAuthEvidence{
+			TermPri:    evidence.termPri,
+			TermPubKey: evidence.termPubKey,
+			SmRapdu:    evidence.smRapdu,
+		}
+	}
 
 	if (*chipAuth.nfcSession).SM() != nil {
 		slog.Debug("doChipAuth", "SM(post)", (*chipAuth.nfcSession).SM().String())
@@ -137,23 +153,23 @@ func resolveCAInfo(secInfos *document.SecurityInfos) (
 	return nil, nil, false, fmt.Errorf("[resolveCAInfo] Unable to resolve caInfo/caAlgInfo")
 }
 
-func (chipAuth *ChipAuth) executeCA(params *ChipAuthParams) error {
+func (chipAuth *ChipAuth) executeCA(params *ChipAuthParams) (*caEcdhEvidence, error) {
 	// process based on the type of key (DH/ECDH)
 	switch {
 	case params.PubKeyInfo.Protocol.Equal(oid.OidPkDh):
 		// DH
-		return fmt.Errorf("[executeCA] DH not currently supported (Raw:%x)", params.PubKeyInfo.Raw)
+		return nil, fmt.Errorf("[executeCA] DH not currently supported (Raw:%x)", params.PubKeyInfo.Raw)
 
 	case params.PubKeyInfo.Protocol.Equal(oid.OidPkEcdh):
 		// ECDH
-		err := chipAuth.doCaEcdh(params)
+		evidence, err := chipAuth.doCaEcdh(params)
 		if err != nil {
-			return fmt.Errorf("[executeCA] doCaEcdh error: %w", err)
+			return nil, fmt.Errorf("[executeCA] doCaEcdh error: %w", err)
 		}
-		return nil
+		return evidence, nil
 
 	default:
-		return fmt.Errorf("[executeCA] unsupported public key type (OID:%s)", params.PubKeyInfo.Protocol.String())
+		return nil, fmt.Errorf("[executeCA] unsupported public key type (OID:%s)", params.PubKeyInfo.Protocol.String())
 	}
 }
 
@@ -388,14 +404,14 @@ func deriveSessionKeys(curve *elliptic.Curve, termKeypair cryptoutils.EcKeypair,
 // performs Chip Authentication in ECDH mode
 // NB we currently implement the AES (2) APDU approach, which should also work for TDES
 //   - we also have special-case handling where we use MSE-SetKAT if the algorithm was inferred and the mode is 3DES-CBC
-func (chipAuth *ChipAuth) doCaEcdh(params *ChipAuthParams) (err error) {
+func (chipAuth *ChipAuth) doCaEcdh(params *ChipAuthParams) (evidence *caEcdhEvidence, err error) {
 	slog.Debug("doCaEcdh", "OID", params.Info.Protocol.String())
 
 	var curve *elliptic.Curve
 	var chipPubKey *cryptoutils.EcPoint
 	curve, chipPubKey, err = params.PubKeyInfo.ChipAuthenticationPublicKey.EcCurveAndPubKey(true)
 	if err != nil {
-		return fmt.Errorf("[doCaEcdh] EcCurveAndPubKey error: %w", err)
+		return nil, fmt.Errorf("[doCaEcdh] EcCurveAndPubKey error: %w", err)
 	}
 
 	slog.Debug("doCaEcdh", "chipPubKey", chipPubKey.String())
@@ -403,22 +419,27 @@ func (chipAuth *ChipAuth) doCaEcdh(params *ChipAuthParams) (err error) {
 	// generate ephemeral key
 	var termKeypair cryptoutils.EcKeypair = chipAuth.keyGeneratorEc(*curve)
 
+	evidence = &caEcdhEvidence{
+		termPri:    bytes.Clone(termKeypair.Pri),
+		termPubKey: cryptoutils.EncodeX962EcPoint(*curve, termKeypair.Pub),
+	}
+
 	slog.Debug("doCaEcdh", "algInferred", params.AlgInferred)
 
 	if params.AlgInferred && params.Info.Protocol.Equal(oid.OidCaEcdh3DesCbcCbc) {
 		err = chipAuth.doMseSetKAT(curve, termKeypair, params.Info)
 		if err != nil {
-			return fmt.Errorf("[doCaEcdh] doMseSetKAT error: %w", err)
+			return nil, fmt.Errorf("[doCaEcdh] doMseSetKAT error: %w", err)
 		}
 	} else {
 		err = chipAuth.doMseSetAT(params.Info)
 		if err != nil {
-			return fmt.Errorf("[doCaEcdh] doMseSetAT error: %w", err)
+			return nil, fmt.Errorf("[doCaEcdh] doMseSetAT error: %w", err)
 		}
 
 		err = chipAuth.doGeneralAuthenticate(curve, termKeypair)
 		if err != nil {
-			return fmt.Errorf("[doCaEcdh] doGeneralAuthenticate error: %w", err)
+			return nil, fmt.Errorf("[doCaEcdh] doGeneralAuthenticate error: %w", err)
 		}
 	}
 
@@ -432,7 +453,7 @@ func (chipAuth *ChipAuth) doCaEcdh(params *ChipAuthParams) (err error) {
 
 		sm, err := iso7816.NewSecureMessaging(params.AlgInfo.cipherAlg, ksEnc, ksMac)
 		if err != nil {
-			return fmt.Errorf("[doCaEcdh] NewSecureMessaging error: %w", err)
+			return nil, fmt.Errorf("[doCaEcdh] NewSecureMessaging error: %w", err)
 		}
 		(*chipAuth.nfcSession).SetSecureMessaging(sm)
 	}
@@ -449,14 +470,110 @@ func (chipAuth *ChipAuth) doCaEcdh(params *ChipAuthParams) (err error) {
 
 		selected, err := (*chipAuth.nfcSession).SelectEF(MRTDFileIdDG14)
 		if err != nil {
-			return fmt.Errorf("[doCaEcdh] SelectEF(DG14) error: %w", err)
+			return nil, fmt.Errorf("[doCaEcdh] SelectEF(DG14) error: %w", err)
 		}
 		if !selected {
-			return fmt.Errorf("[doCaEcdh] unable to select DG14 after performing CA")
+			return nil, fmt.Errorf("[doCaEcdh] unable to select DG14 after performing CA")
 		}
 	}
 
-	return nil
+	// capture the SM-encrypted RAPDU from the verification SelectEF
+	lastApdu := (*chipAuth.nfcSession).LastApdu()
+	if lastApdu != nil && lastApdu.Child != nil {
+		evidence.smRapdu = bytes.Clone(lastApdu.Child.Rx)
+	}
+
+	return evidence, nil
+}
+
+// VerifyEvidence independently verifies Chip Authentication evidence without a live
+// NFC session. It requires only the Document (which supplies the chip's EC public key
+// from DG14 via selectChipAuthParams) and the evidence captured during the original
+// CA session (ephemeral terminal keypair + SM-encrypted RAPDU).
+//
+// Verification steps:
+//  1. Resolve CA parameters from the Document (algorithm, chip public key, curve).
+//  2. Reconstruct the terminal keypair from the evidence.
+//  3. Re-derive the shared secret and session keys (ksEnc, ksMac) via ECDH + KDF.
+//  4. Verify the SM MAC on the captured RAPDU using ksMac.
+//  5. Confirm the decrypted RAPDU status is 9000 (success).
+//
+// A successful result proves the chip held the private key matching the public
+// key in DG14 during the original session. However, this alone does not prove
+// the chip is genuine — a clone could generate its own keypair and produce valid
+// evidence against it. Callers must also verify the Document via Passive
+// Authentication to confirm that DG14 (and hence the chip's public key) is
+// bound to a trusted CSCA chain. Only the combination of successful evidence
+// verification and Passive Authentication constitutes an anti-cloning verdict.
+//
+// This function does not perform replay detection. Applications should implement
+// their own checks (e.g. tracking previously seen evidence) to prevent a valid
+// evidence payload from being submitted more than once.
+const maxEvidenceFieldLen = 1024
+
+func VerifyEvidence(doc *document.Document, evidence *document.ChipAuthEvidence) (*document.ChipAuthResult, error) {
+	if evidence == nil {
+		return nil, fmt.Errorf("[VerifyEvidence] evidence is nil")
+	}
+
+	if len(evidence.TermPri) == 0 || len(evidence.TermPubKey) == 0 || len(evidence.SmRapdu) == 0 {
+		return nil, fmt.Errorf("[VerifyEvidence] evidence has empty field(s)")
+	}
+
+	if len(evidence.TermPri) > maxEvidenceFieldLen ||
+		len(evidence.TermPubKey) > maxEvidenceFieldLen ||
+		len(evidence.SmRapdu) > maxEvidenceFieldLen {
+		return nil, fmt.Errorf("[VerifyEvidence] evidence field exceeds maximum length (%d)", maxEvidenceFieldLen)
+	}
+
+	params, err := selectChipAuthParams(doc)
+	if err != nil {
+		return nil, fmt.Errorf("[VerifyEvidence] selectChipAuthParams error: %w", err)
+	}
+
+	var curve *elliptic.Curve
+	var chipPubKey *cryptoutils.EcPoint
+	curve, chipPubKey, err = params.PubKeyInfo.ChipAuthenticationPublicKey.EcCurveAndPubKey(true)
+	if err != nil {
+		return nil, fmt.Errorf("[VerifyEvidence] EcCurveAndPubKey error: %w", err)
+	}
+
+	// reconstruct the terminal keypair from the evidence
+	termPub, err := cryptoutils.DecodeX962EcPoint(*curve, evidence.TermPubKey)
+	if err != nil {
+		return nil, fmt.Errorf("[VerifyEvidence] DecodeX962EcPoint error: %w", err)
+	}
+
+	termKeypair := cryptoutils.EcKeypair{
+		Pri: evidence.TermPri,
+		Pub: termPub,
+	}
+
+	ksEnc, ksMac := deriveSessionKeys(curve, termKeypair, chipPubKey, params.AlgInfo)
+
+	sm, err := iso7816.NewSecureMessaging(params.AlgInfo.cipherAlg, ksEnc, ksMac)
+	if err != nil {
+		return nil, fmt.Errorf("[VerifyEvidence] NewSecureMessaging error: %w", err)
+	}
+
+	// set SSC to 1 so that sm.Decode (which increments before use) verifies at SSC=2,
+	// matching the state during the original CA session (Encode incremented to 1, Decode to 2)
+	ssc := make([]byte, len(sm.SSC()))
+	new(big.Int).SetInt64(1).FillBytes(ssc)
+	if err = sm.SetSSC(ssc); err != nil {
+		return nil, fmt.Errorf("[VerifyEvidence] SetSSC error: %w", err)
+	}
+
+	rApdu, err := sm.Decode(evidence.SmRapdu)
+	if err != nil {
+		return nil, fmt.Errorf("[VerifyEvidence] SM MAC verification failed: %w", err)
+	}
+
+	if !rApdu.IsSuccess() {
+		return nil, fmt.Errorf("[VerifyEvidence] RAPDU status is not success (status:%04x)", rApdu.Status)
+	}
+
+	return &document.ChipAuthResult{Success: true, Evidence: evidence}, nil
 }
 
 // dynamic authentication data - (TLV) 7C <tag> <data>

--- a/chipauth/chip_auth_test.go
+++ b/chipauth/chip_auth_test.go
@@ -289,10 +289,26 @@ func TestChipAuthAT(t *testing.T) {
 		t.Errorf("Unexpected error: %s", err)
 	}
 
-	// verify Result is as expected
-	var expResult *document.ChipAuthResult = &document.ChipAuthResult{Success: true}
+	var expResult *document.ChipAuthResult = &document.ChipAuthResult{
+		Success: true,
+		Evidence: &document.ChipAuthEvidence{
+			TermPri:    utils.HexToBytes("80EBAFC8A51BECD4D90BB640EE38C9FD5C12748D28AAA37096B98C4533C4F5F5"),
+			TermPubKey: utils.HexToBytes("044827C781BE1AC7A00B351214FD783AC76D99E831A6316C8FD6DE7BD96CFA31DA06B6B57BA380789729F4A028212A768C49BF5F97D98B1DB12BEEC1A1CD324FB2"),
+			SmRapdu:    utils.HexToBytes("990290008E0803C4B125B4218CEF9000"),
+		},
+	}
+
 	if !reflect.DeepEqual(result, expResult) {
-		t.Errorf("Result differs to expected [Act] %+v [Exp] %+v", result, expResult)
+		t.Fatalf("Result differs to expected")
+	}
+
+	// verify that evidence can be independently verified
+	verifyResult, err := VerifyEvidence(doc, result.Evidence)
+	if err != nil {
+		t.Errorf("VerifyEvidence unexpected error: %s", err)
+	}
+	if verifyResult == nil || !verifyResult.Success {
+		t.Errorf("VerifyEvidence expected success")
 	}
 
 	var smExp *iso7816.SecureMessaging
@@ -388,10 +404,26 @@ func TestChipAuthDE(t *testing.T) {
 		t.Errorf("Unexpected error: %s", err)
 	}
 
-	// verify Result is as expected
-	var expResult *document.ChipAuthResult = &document.ChipAuthResult{Success: true}
+	var expResult *document.ChipAuthResult = &document.ChipAuthResult{
+		Success: true,
+		Evidence: &document.ChipAuthEvidence{
+			TermPri:    utils.HexToBytes("84a5145885678ee9307c28c52736896267511203b7b8009c5fe27abcbaecdcaa"),
+			TermPubKey: utils.HexToBytes("04897fa47c895d35949a8db8f776a62d775bdf764a1aa1bdc2d8fc96cd5c2e80e39f631c67e84364dcf85f5c9f8ce79a752071896819a0d510cf9701652486817c"),
+			SmRapdu:    utils.HexToBytes("990290008e0829d0e1ebbb61be7a9000"),
+		},
+	}
+
 	if !reflect.DeepEqual(result, expResult) {
-		t.Errorf("Result differs to expected [Act] %+v [Exp] %+v", result, expResult)
+		t.Fatalf("Result differs to expected")
+	}
+
+	// verify that evidence can be independently verified
+	verifyResult, err := VerifyEvidence(doc, result.Evidence)
+	if err != nil {
+		t.Errorf("VerifyEvidence unexpected error: %s", err)
+	}
+	if verifyResult == nil || !verifyResult.Success {
+		t.Errorf("VerifyEvidence expected success")
 	}
 
 	var smExp *iso7816.SecureMessaging
@@ -487,10 +519,26 @@ func TestChipAuthMY(t *testing.T) {
 		t.Errorf("Unexpected error: %s", err)
 	}
 
-	// verify Result is as expected
-	var expResult *document.ChipAuthResult = &document.ChipAuthResult{Success: true}
+	var expResult *document.ChipAuthResult = &document.ChipAuthResult{
+		Success: true,
+		Evidence: &document.ChipAuthEvidence{
+			TermPri:    utils.HexToBytes("3a31f4e18418312fcb40f3efbe719182c046a9719e1ed8c376197aa9e8ed7465"),
+			TermPubKey: utils.HexToBytes("043da6d3b923689b96aa65d744f1bd1537fcf1f8a5dd9bc6b01d7b30fc1812645b510cb66bed899c67a802a7881313e4bca87055cde3cf615efdbadbb64bc32462"),
+			SmRapdu:    utils.HexToBytes("990290008e08c2bf01fddd1d599d9000"),
+		},
+	}
+
 	if !reflect.DeepEqual(result, expResult) {
-		t.Errorf("Result differs to expected [Act] %+v [Exp] %+v", result, expResult)
+		t.Fatalf("Result differs to expected")
+	}
+
+	// verify that evidence can be independently verified
+	verifyResult, err := VerifyEvidence(doc, result.Evidence)
+	if err != nil {
+		t.Errorf("VerifyEvidence unexpected error: %s", err)
+	}
+	if verifyResult == nil || !verifyResult.Success {
+		t.Errorf("VerifyEvidence expected success")
 	}
 
 	var smExp *iso7816.SecureMessaging
@@ -584,10 +632,26 @@ func TestChipAuthFR(t *testing.T) {
 		t.Errorf("Unexpected error: %s", err)
 	}
 
-	// verify Result is as expected
-	var expResult *document.ChipAuthResult = &document.ChipAuthResult{Success: true}
+	var expResult *document.ChipAuthResult = &document.ChipAuthResult{
+		Success: true,
+		Evidence: &document.ChipAuthEvidence{
+			TermPri:    utils.HexToBytes("d9c3b06a4dcb735351429403fcb56db520dc882512d775971f724d6112f96586"),
+			TermPubKey: utils.HexToBytes("04334f809c8842a4c9316c19e52a0d6ea0285996c40ff6db303cef72099198c8ad5d6b46e93482de899533d06eac54c289df5aa1436a846fb9154100c5322439ea"),
+			SmRapdu:    utils.HexToBytes("990290008e08420dea0a913418ae9000"),
+		},
+	}
+
 	if !reflect.DeepEqual(result, expResult) {
-		t.Errorf("Result differs to expected [Act] %+v [Exp] %+v", result, expResult)
+		t.Fatalf("Result differs to expected")
+	}
+
+	// verify that evidence can be independently verified
+	verifyResult, err := VerifyEvidence(&doc, result.Evidence)
+	if err != nil {
+		t.Errorf("VerifyEvidence unexpected error: %s", err)
+	}
+	if verifyResult == nil || !verifyResult.Success {
+		t.Errorf("VerifyEvidence expected success")
 	}
 
 	var smExp *iso7816.SecureMessaging
@@ -749,7 +813,7 @@ func TestExecuteCA(t *testing.T) {
 				Protocol: oid.OidPkDh,
 			},
 		}
-		err := chipAuth.executeCA(params)
+		_, err := chipAuth.executeCA(params)
 		if err == nil {
 			t.Error("expected error for DH key type")
 		}
@@ -761,9 +825,121 @@ func TestExecuteCA(t *testing.T) {
 				Protocol: oid.OidPk,
 			},
 		}
-		err := chipAuth.executeCA(params)
+		_, err := chipAuth.executeCA(params)
 		if err == nil {
 			t.Error("expected error for unknown key type")
+		}
+	})
+}
+
+func TestVerifyEvidence(t *testing.T) {
+	// use AT test data to construct valid evidence, then test various invalid inputs
+	dg14bytes := utils.HexToBytes("6E82017E3182017A300D060804007F0007020202020101300F060A04007F000702020302020201013012060A04007F0007020204020202010202010D30820142060904007F000702020102308201333081EC06072A8648CE3D02013081E0020101302C06072A8648CE3D0101022100A9FB57DBA1EEA9BC3E660A909D838D726E3BF623D52620282013481D1F6E5377304404207D5A0975FC2C3057EEF67530417AFFE7FB8055C126DC5C6CE94A4B44F330B5D9042026DC5C6CE94A4B44F330B5D9BBD77CBF958416295CF7E1CE6BCCDC18FF8C07B60441048BD2AEB9CB7E57CB2C4B482FFC81B7AFB9DE27E1E3BD23C23A4453BD9ACE3262547EF835C3DAC4FD97F8461A14611DC9C27745132DED8E545C1D54C72F046997022100A9FB57DBA1EEA9BC3E660A909D838D718C397AA3B561A6F7901E0E82974856A7020101034200041983917269AC877C0B61544C2C022000D2A5ABA723E2D80141E648B40911DC3459761F27480E4B57181A53D8FE1190EA86C939AC14363178CAFFC621F0F905C3")
+
+	doc := &document.Document{}
+	if err := doc.NewDG(14, dg14bytes); err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+
+	// valid evidence captured from AT test (SM RAPDU for Select EF DG14)
+	validEvidence := &document.ChipAuthEvidence{
+		TermPri:    utils.HexToBytes("80EBAFC8A51BECD4D90BB640EE38C9FD5C12748D28AAA37096B98C4533C4F5F5"),
+		TermPubKey: utils.HexToBytes("044827C781BE1AC7A00B351214FD783AC76D99E831A6316C8FD6DE7BD96CFA31DA06B6B57BA380789729F4A028212A768C49BF5F97D98B1DB12BEEC1A1CD324FB2"),
+		SmRapdu:    utils.HexToBytes("990290008E0803C4B125B4218CEF9000"),
+	}
+
+	t.Run("nil evidence", func(t *testing.T) {
+		_, err := VerifyEvidence(doc, nil)
+		if err == nil {
+			t.Error("expected error for nil evidence")
+		}
+	})
+
+	t.Run("empty TermPri", func(t *testing.T) {
+		e := &document.ChipAuthEvidence{
+			TermPri:    nil,
+			TermPubKey: validEvidence.TermPubKey,
+			SmRapdu:    validEvidence.SmRapdu,
+		}
+		_, err := VerifyEvidence(doc, e)
+		if err == nil {
+			t.Error("expected error for empty TermPri")
+		}
+	})
+
+	t.Run("empty SmRapdu", func(t *testing.T) {
+		e := &document.ChipAuthEvidence{
+			TermPri:    validEvidence.TermPri,
+			TermPubKey: validEvidence.TermPubKey,
+			SmRapdu:    nil,
+		}
+		_, err := VerifyEvidence(doc, e)
+		if err == nil {
+			t.Error("expected error for empty SmRapdu")
+		}
+	})
+
+	t.Run("oversized field", func(t *testing.T) {
+		e := &document.ChipAuthEvidence{
+			TermPri:    validEvidence.TermPri,
+			TermPubKey: validEvidence.TermPubKey,
+			SmRapdu:    make([]byte, maxEvidenceFieldLen+1),
+		}
+		_, err := VerifyEvidence(doc, e)
+		if err == nil {
+			t.Error("expected error for oversized SmRapdu")
+		}
+	})
+
+	t.Run("wrong private key", func(t *testing.T) {
+		e := &document.ChipAuthEvidence{
+			TermPri:    utils.HexToBytes("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+			TermPubKey: validEvidence.TermPubKey,
+			SmRapdu:    validEvidence.SmRapdu,
+		}
+		_, err := VerifyEvidence(doc, e)
+		if err == nil {
+			t.Error("expected error for wrong private key")
+		}
+	})
+
+	t.Run("non-9000 status", func(t *testing.T) {
+		e := &document.ChipAuthEvidence{
+			TermPri:    validEvidence.TermPri,
+			TermPubKey: validEvidence.TermPubKey,
+			SmRapdu:    utils.HexToBytes("990269828E0870AD2E8835E91DEA6982"),
+		}
+		_, err := VerifyEvidence(doc, e)
+		if err == nil {
+			t.Error("expected error for non-9000 RAPDU status")
+		}
+	})
+
+	t.Run("corrupted SmRapdu", func(t *testing.T) {
+		corrupted := make([]byte, len(validEvidence.SmRapdu))
+		copy(corrupted, validEvidence.SmRapdu)
+		corrupted[len(corrupted)-3] ^= 0xFF
+		e := &document.ChipAuthEvidence{
+			TermPri:    validEvidence.TermPri,
+			TermPubKey: validEvidence.TermPubKey,
+			SmRapdu:    corrupted,
+		}
+		_, err := VerifyEvidence(doc, e)
+		if err == nil {
+			t.Error("expected error for corrupted SmRapdu")
+		}
+	})
+
+	t.Run("valid evidence", func(t *testing.T) {
+		result, err := VerifyEvidence(doc, validEvidence)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+		if result == nil || !result.Success {
+			t.Error("expected success")
+		}
+		if result.Evidence == nil {
+			t.Error("expected evidence in result")
 		}
 	})
 }

--- a/document/session.go
+++ b/document/session.go
@@ -149,8 +149,23 @@ func (result ActiveAuthResult) MarshalJSON() ([]byte, error) {
 	})
 }
 
+// ChipAuthEvidence holds the ephemeral terminal keypair and the SM-encrypted RAPDU from
+// the CA verification step. Together with the Document (which contains the chip's public
+// key in DG14), this is sufficient for independent cryptographic re-verification.
+//
+// The ephemeral terminal private key is safe to include: it is generated fresh for each
+// CA session and has no value afterwards — the terminal will use a new keypair on the next
+// session. Including it enables the verifier to re-derive the shared secret and session
+// keys, then verify the SM MAC on the RAPDU.
+type ChipAuthEvidence struct {
+	TermPri    []byte `json:"termPri,omitempty"`
+	TermPubKey []byte `json:"termPubKey,omitempty"`
+	SmRapdu    []byte `json:"smRapdu,omitempty"`
+}
+
 type ChipAuthResult struct {
-	Success bool `json:"success"`
+	Success  bool              `json:"success"`
+	Evidence *ChipAuthEvidence `json:"evidence,omitempty"`
 }
 
 type ChipAuthStatus int


### PR DESCRIPTION
## Summary
  
  - Capture the ephemeral terminal keypair and SM-encrypted RAPDU during Chip Authentication, returning them as `ChipAuthEvidence` on `ChipAuthResult`
  - Add `VerifyEvidence` for offline re-verification of CA evidence using only the `Document` (DG14) and captured evidence — re-derives session keys via ECDH+KDF, verifies the SM MAC, and confirms the RAPDU status is 9000
  - Add `ChipAuthEvidence` struct to `document/session.go` with JSON serialisation support

  ## Detail

  During the live CA flow (`doCaEcdh`), after SM is established and verified with a `SelectEF(DG14)`, the raw SM-encrypted RAPDU and ephemeral terminal key material are now captured as evidence. This enables a separate verifier to
  independently confirm the chip held the private key matching the DG14 public key, without needing a live NFC session.

  `VerifyEvidence` validates:
  1. Input bounds (nil, empty, max-length checks)
  2. SM MAC integrity using re-derived session keys
  3. Decrypted RAPDU status is 9000 (not just a valid MAC on a failure response)

  ## Test plan

  - [x] Existing CA tests (AT, DE, MY, FR) updated to verify evidence is populated and round-trips through `VerifyEvidence`
  - [x] `TestVerifyEvidence` covers: nil evidence, empty fields, oversized fields, wrong private key, non-9000 RAPDU status, corrupted MAC, and valid evidence
  - [x] Full `chipauth` test suite passes