### PR TITLE
fix(mobile): Add Android 16 KB page-size compatible AAR

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -61,15 +61,18 @@ jobs:
           go install golang.org/x/mobile/cmd/gobind@latest
       - name: gomobile init
         run: gomobile init
-      - name: Build Android AAR
-        run: make android
-        env:
-          ANDROID_NDK: ${{ env.ANDROID_NDK_LATEST_HOME }}
-      - name: Save Android artifact
+      - name: Build Android AARs
+        run: |
+          ANDROID_NDK="$ANDROID_NDK_LATEST_HOME" \
+          ANDROID_NDK_HOME="$ANDROID_NDK_LATEST_HOME" \
+          make android
+      - name: Save Android artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: android-aar
-          path: dist/android/gmrtd.aar
+          name: android-aars
+          path: |
+            dist/android/gmrtd.aar
+            dist/android/gmrtd-android-16kb.aar
 
   upload-assets:
     needs: [release, build-ios, build-android]
@@ -85,15 +88,16 @@ jobs:
       - name: Download Android artifact
         uses: actions/download-artifact@v4
         with:
-          name: android-aar
+          name: android-aars
           path: dist/android
       - name: Generate checksums
-        run: cd dist && sha256sum ios/Gmrtd.xcframework.zip android/gmrtd.aar > checksums.txt
+        run: cd dist && sha256sum ios/Gmrtd.xcframework.zip android/gmrtd.aar android/gmrtd-android-16kb.aar > checksums.txt
       - name: Upload release assets
         run: |
           gh release upload ${{ needs.release.outputs.tag_name }} \
             dist/ios/Gmrtd.xcframework.zip \
             dist/android/gmrtd.aar \
+            dist/android/gmrtd-android-16kb.aar \
             dist/checksums.txt
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ ANDROID_OUT         ?= dist/android
 TEST_OUT            ?= dist/test
 IOS_NAME            ?= Gmrtd
 AAR_NAME            ?= gmrtd.aar
+AAR_16KB_NAME       ?= gmrtd-android-16kb.aar
 
 # -------- Toolchain / Versions --------
 MIN_IOS             ?= 13.0
@@ -36,7 +37,7 @@ export IPHONEOS_DEPLOYMENT_TARGET ?= $(MIN_IOS)
 
 # -------- Phonies --------
 .PHONY: all clean tools lint-tools gomobile-init verify-env \
-        ios android release checksums \
+        ios android android-16kb release checksums \
         test test-short test-race cover bench \
         fmt vet lint vuln tidy modverify gen ci
 
@@ -86,7 +87,7 @@ $(IOS_OUT)/$(IOS_NAME).xcframework:
 # =======================
 # Android binding
 # =======================
-android: $(ANDROID_OUT)/$(AAR_NAME)
+android: $(ANDROID_OUT)/$(AAR_NAME) $(ANDROID_OUT)/$(AAR_16KB_NAME)
 $(ANDROID_OUT)/$(AAR_NAME):
 	mkdir -p $(ANDROID_OUT)
 	ANDROID_HOME=$(ANDROID_HOME) ANDROID_NDK=$(ANDROID_NDK) \
@@ -98,6 +99,20 @@ $(ANDROID_OUT)/$(AAR_NAME):
 		$(if $(GO_TAGS),-tags "$(GO_TAGS)",) \
 		$(PKG_MOBILE)
 	@echo ">> Android AAR at $(ANDROID_OUT)/$(AAR_NAME)"
+
+android-16kb: $(ANDROID_OUT)/$(AAR_16KB_NAME)
+$(ANDROID_OUT)/$(AAR_16KB_NAME):
+	mkdir -p $(ANDROID_OUT)
+	ANDROID_HOME=$(ANDROID_HOME) ANDROID_NDK=$(ANDROID_NDK) \
+	gomobile bind -v \
+		-target=android/arm64,android/amd64 \
+		-androidapi=$(MIN_ANDROID_SDK) \
+		-javapkg $(ANDROID_JAVAPKG) \
+		-ldflags='-R=16384' \
+		-o $(ANDROID_OUT)/$(AAR_16KB_NAME) \
+		$(if $(GO_TAGS),-tags "$(GO_TAGS)",) \
+		$(PKG_MOBILE)
+	@echo ">> Android 16 KB page-size compatible AAR at $(ANDROID_OUT)/$(AAR_16KB_NAME)"
 
 # =======================
 # Releases / checksums

--- a/README.md
+++ b/README.md
@@ -171,6 +171,14 @@ Together these cover **121 countries**. These defaults can be replaced, extended
 - Transports: PC/SC, Core NFC, Android NFC, custom APDU transceivers
 - Platforms: Desktop, mobile, embedded
 
+## Android AAR Artifacts
+Release assets include two Android AARs:
+
+- `gmrtd.aar`: legacy/full ABI artifact for `armeabi-v7a`, `arm64-v8a`, and `x86_64`.
+- `gmrtd-android-16kb.aar`: 16 KB page-size compatible artifact for `arm64-v8a` and `x86_64`.
+
+Use `gmrtd-android-16kb.aar` for apps that need Android 16 KB page-size compatibility. Use `gmrtd.aar` if your app still needs 32-bit Android support.
+
 # 📚 Specifications
 - [ICAO Doc 9303 — Machine Readable Travel Documents](https://www.icao.int/publications/pages/publication.aspx?docnum=9303)
 - [ISO/IEC 7816-4 — Smart card command interface](https://www.iso.org/obp/ui/#iso:std:iso-iec:7816:-4)

--- a/go.mod
+++ b/go.mod
@@ -19,3 +19,5 @@ require (
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/tools v0.43.0 // indirect
 )
+
+tool golang.org/x/mobile/cmd/gobind

--- a/go.sum
+++ b/go.sum
@@ -25,3 +25,7 @@ golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/tools v0.43.0 h1:12BdW9CeB3Z+J/I/wj34VMl8X+fEXBxVR90JeMX5E7s=
 golang.org/x/tools v0.43.0/go.mod h1:uHkMso649BX2cZK6+RpuIPXS3ho2hZo4FVwfoy1vIk0=
+golang.org/x/tools/go/expect v0.1.1-deprecated h1:jpBZDwmgPhXsKZC6WhL20P4b/wmnpsEAGHaNy0n/rJM=
+golang.org/x/tools/go/expect v0.1.1-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
+golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated h1:1h2MnaIAIXISqTFKdENegdpAgUXz6NrPEsbIeWaBRvM=
+golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated/go.mod h1:RVAQXBGNv1ib0J382/DPCRS/BPnsGebyM1Gj5VSDpG8=


### PR DESCRIPTION
## Summary

Adds a second Android AAR for 16 KB page-size compatible 64-bit native libraries while preserving the existing full-ABI artifact for legacy 32-bit support.

## Why this change

Apps consuming the existing release AAR, including `gmrtd.aar` from v0.32.0, can show Android's native-library page-size compatibility warning dialog because `libgojni.so` has 4 KB ELF LOAD alignment.

Building the 64-bit gomobile bindings with `-ldflags='-R=16384'` produces `libgojni.so` LOAD segments aligned to 16 KB, addressing that warning for supported 64-bit ABIs.

The existing `gmrtd.aar` remains the legacy/full ABI artifact (`armeabi-v7a`, `arm64-v8a`, `x86_64`). The new `gmrtd-android-16kb.aar` deliberately contains only `arm64-v8a` and `x86_64`. Splitting the artifacts makes 16 KB compatibility available without removing 32-bit Android support for existing consumers.

## Changes

- Build `dist/android/gmrtd.aar` with the existing full ABI set.
- Build `dist/android/gmrtd-android-16kb.aar` for `arm64-v8a` and `x86_64` with `-ldflags='-R=16384'`.
- Upload, checksum, and release both AARs.
- Document which artifact Android app developers should use.
- Declare `gobind` as a Go tool so current Go 1.25/gomobile builds work reliably.

## CI note

The workflow now reads `ANDROID_NDK_LATEST_HOME` from the runner shell environment when invoking `make android`, rather than through the workflow expression `env` context. It sets both `ANDROID_NDK` and `ANDROID_NDK_HOME`, because gomobile may consult either variable.

## Verification

- `make test-short`
- `go mod tidy`
- `go mod verify`
- `make -B android` with Android NDK 28.2.13676358
- Verified legacy AAR contains `armeabi-v7a`, `arm64-v8a`, and `x86_64`.
- Verified 16 KB AAR contains `arm64-v8a` and `x86_64` only.
- `llvm-objdump -p` on `jni/arm64-v8a/libgojni.so` reports LOAD segment alignment `2**14`.