### PR TITLE
feat(session):add CBOR serialization for chip auth evidence

### DIFF
--- a/document/session_cbor.go
+++ b/document/session_cbor.go
@@ -1,0 +1,156 @@
+package document
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/asn1"
+	"fmt"
+
+	cbor "github.com/fxamacker/cbor/v2"
+)
+
+type cborPaceCamEvidence struct {
+	PaceOid     []int  `cbor:"paceOid"`
+	ParameterId int    `cbor:"parameterId"`
+	Nonce       []byte `cbor:"nonce"`
+	TermMapPri  []byte `cbor:"termMapPri"`
+	ChipMapPub  []byte `cbor:"chipMapPub"`
+	TermKaPri   []byte `cbor:"termKaPri"`
+	ChipKaPub   []byte `cbor:"chipKaPub"`
+	EcadIC      []byte `cbor:"ecadIC"`
+}
+
+type cborCAEvidence struct {
+	TermPri    []byte `cbor:"termPri,omitempty"`
+	TermPubKey []byte `cbor:"termPubKey,omitempty"`
+	SmRapdu    []byte `cbor:"smRapdu,omitempty"`
+}
+
+type cborAAEvidence struct {
+	Algorithm []int  `cbor:"algorithm"`
+	Nonce     []byte `cbor:"nonce"`
+	Signature []byte `cbor:"signature"`
+}
+
+type cborChipAuthBundle struct {
+	PaceCam    *cborPaceCamEvidence `cbor:"paceCam,omitempty"`
+	ChipAuth   *cborCAEvidence      `cbor:"chipAuth,omitempty"`
+	ActiveAuth *cborAAEvidence      `cbor:"activeAuth,omitempty"`
+}
+
+const chipAuthEvidenceMagic = "gmrtd-chip-auth-evidence"
+const chipAuthEvidenceVersion uint = 1
+
+type ChipAuthEvidenceBundle struct {
+	PaceCam    *PaceCamEvidence
+	ChipAuth   *ChipAuthEvidence
+	ActiveAuth *ActiveAuthEvidence
+}
+
+func (session *Session) ChipAuthEvidenceToCbor() ([]byte, error) {
+	var bundle cborChipAuthBundle
+
+	if session.PaceCamResult != nil && session.PaceCamResult.Evidence != nil {
+		e := session.PaceCamResult.Evidence
+		bundle.PaceCam = &cborPaceCamEvidence{
+			PaceOid:     []int(e.PaceOid),
+			ParameterId: e.ParameterId,
+			Nonce:       e.Nonce,
+			TermMapPri:  e.TermMapPri,
+			ChipMapPub:  e.ChipMapPub,
+			TermKaPri:   e.TermKaPri,
+			ChipKaPub:   e.ChipKaPub,
+			EcadIC:      e.EcadIC,
+		}
+	}
+
+	if session.ChipAuthResult != nil && session.ChipAuthResult.Evidence != nil {
+		e := session.ChipAuthResult.Evidence
+		bundle.ChipAuth = &cborCAEvidence{
+			TermPri:    e.TermPri,
+			TermPubKey: e.TermPubKey,
+			SmRapdu:    e.SmRapdu,
+		}
+	}
+
+	if session.ActiveAuthResult != nil && session.ActiveAuthResult.Evidence != nil {
+		e := session.ActiveAuthResult.Evidence
+		bundle.ActiveAuth = &cborAAEvidence{
+			Algorithm: []int(e.Algorithm),
+			Nonce:     e.Nonce,
+			Signature: e.Signature,
+		}
+	}
+
+	payload, err := cbor.Marshal(bundle)
+	if err != nil {
+		return nil, fmt.Errorf("[ChipAuthEvidenceToCbor] cbor.Marshal error: %w", err)
+	}
+
+	digest := sha256.Sum256(payload)
+	env := cborEnvelope{
+		Magic:   chipAuthEvidenceMagic,
+		Version: chipAuthEvidenceVersion,
+		SHA256:  digest[:],
+		Payload: payload,
+	}
+
+	return cbor.Marshal(env)
+}
+
+func NewChipAuthEvidenceFromCbor(data []byte) (*ChipAuthEvidenceBundle, error) {
+	var env cborEnvelope
+	if err := cbor.Unmarshal(data, &env); err != nil {
+		return nil, fmt.Errorf("[NewChipAuthEvidenceFromCbor] cbor.Unmarshal(envelope) error: %w", err)
+	}
+
+	if env.Magic != chipAuthEvidenceMagic {
+		return nil, fmt.Errorf("[NewChipAuthEvidenceFromCbor] unrecognised magic %q (want %q)", env.Magic, chipAuthEvidenceMagic)
+	}
+	if env.Version > chipAuthEvidenceVersion {
+		return nil, fmt.Errorf("[NewChipAuthEvidenceFromCbor] unsupported version %d (max supported: %d)", env.Version, chipAuthEvidenceVersion)
+	}
+
+	digest := sha256.Sum256(env.Payload)
+	if !bytes.Equal(digest[:], env.SHA256) {
+		return nil, fmt.Errorf("[NewChipAuthEvidenceFromCbor] SHA-256 checksum mismatch: payload is corrupt")
+	}
+
+	var bundle cborChipAuthBundle
+	if err := cbor.Unmarshal(env.Payload, &bundle); err != nil {
+		return nil, fmt.Errorf("[NewChipAuthEvidenceFromCbor] cbor.Unmarshal(bundle) error: %w", err)
+	}
+
+	var result ChipAuthEvidenceBundle
+
+	if bundle.PaceCam != nil {
+		result.PaceCam = &PaceCamEvidence{
+			PaceOid:     asn1.ObjectIdentifier(bundle.PaceCam.PaceOid),
+			ParameterId: bundle.PaceCam.ParameterId,
+			Nonce:       bundle.PaceCam.Nonce,
+			TermMapPri:  bundle.PaceCam.TermMapPri,
+			ChipMapPub:  bundle.PaceCam.ChipMapPub,
+			TermKaPri:   bundle.PaceCam.TermKaPri,
+			ChipKaPub:   bundle.PaceCam.ChipKaPub,
+			EcadIC:      bundle.PaceCam.EcadIC,
+		}
+	}
+
+	if bundle.ChipAuth != nil {
+		result.ChipAuth = &ChipAuthEvidence{
+			TermPri:    bundle.ChipAuth.TermPri,
+			TermPubKey: bundle.ChipAuth.TermPubKey,
+			SmRapdu:    bundle.ChipAuth.SmRapdu,
+		}
+	}
+
+	if bundle.ActiveAuth != nil {
+		result.ActiveAuth = &ActiveAuthEvidence{
+			Algorithm: asn1.ObjectIdentifier(bundle.ActiveAuth.Algorithm),
+			Nonce:     bundle.ActiveAuth.Nonce,
+			Signature: bundle.ActiveAuth.Signature,
+		}
+	}
+
+	return &result, nil
+}

--- a/document/session_cbor_test.go
+++ b/document/session_cbor_test.go
@@ -1,0 +1,319 @@
+package document
+
+import (
+	"bytes"
+	"encoding/asn1"
+	"testing"
+
+	cbor "github.com/fxamacker/cbor/v2"
+)
+
+func TestChipAuthEvidenceToCborEmpty(t *testing.T) {
+	var session Session
+
+	cborBytes, err := session.ChipAuthEvidenceToCbor()
+	if err != nil {
+		t.Fatalf("ChipAuthEvidenceToCbor error on empty session: %s", err)
+	}
+	if len(cborBytes) == 0 {
+		t.Fatal("ChipAuthEvidenceToCbor returned empty bytes")
+	}
+
+	result, err := NewChipAuthEvidenceFromCbor(cborBytes)
+	if err != nil {
+		t.Fatalf("NewChipAuthEvidenceFromCbor error: %s", err)
+	}
+	if result.PaceCam != nil || result.ChipAuth != nil || result.ActiveAuth != nil {
+		t.Error("expected all evidence to be nil for empty session")
+	}
+}
+
+func TestChipAuthEvidenceToCborPaceCam(t *testing.T) {
+	src := &PaceCamEvidence{
+		PaceOid:     asn1.ObjectIdentifier{0, 4, 0, 127, 0, 7, 2, 2, 4, 2, 4},
+		ParameterId: 13,
+		Nonce:       []byte{0x01, 0x02, 0x03},
+		TermMapPri:  []byte{0x04, 0x05},
+		ChipMapPub:  []byte{0x06, 0x07},
+		TermKaPri:   []byte{0x08, 0x09},
+		ChipKaPub:   []byte{0x0a, 0x0b},
+		EcadIC:      []byte{0x0c, 0x0d},
+	}
+
+	session := Session{
+		PaceCamResult: &PaceCamResult{Success: true, Evidence: src},
+	}
+
+	cborBytes, err := session.ChipAuthEvidenceToCbor()
+	if err != nil {
+		t.Fatalf("ChipAuthEvidenceToCbor error: %s", err)
+	}
+
+	result, err := NewChipAuthEvidenceFromCbor(cborBytes)
+	if err != nil {
+		t.Fatalf("NewChipAuthEvidenceFromCbor error: %s", err)
+	}
+
+	if result.PaceCam == nil {
+		t.Fatal("expected PaceCam evidence to be non-nil")
+	}
+	got := result.PaceCam
+	if !got.PaceOid.Equal(src.PaceOid) {
+		t.Errorf("PaceOid mismatch: want %s, got %s", src.PaceOid, got.PaceOid)
+	}
+	if got.ParameterId != src.ParameterId {
+		t.Errorf("ParameterId mismatch: want %d, got %d", src.ParameterId, got.ParameterId)
+	}
+	if !bytes.Equal(got.Nonce, src.Nonce) {
+		t.Error("Nonce mismatch")
+	}
+	if !bytes.Equal(got.TermMapPri, src.TermMapPri) {
+		t.Error("TermMapPri mismatch")
+	}
+	if !bytes.Equal(got.ChipMapPub, src.ChipMapPub) {
+		t.Error("ChipMapPub mismatch")
+	}
+	if !bytes.Equal(got.TermKaPri, src.TermKaPri) {
+		t.Error("TermKaPri mismatch")
+	}
+	if !bytes.Equal(got.ChipKaPub, src.ChipKaPub) {
+		t.Error("ChipKaPub mismatch")
+	}
+	if !bytes.Equal(got.EcadIC, src.EcadIC) {
+		t.Error("EcadIC mismatch")
+	}
+
+	if result.ChipAuth != nil {
+		t.Error("expected ChipAuth to be nil")
+	}
+	if result.ActiveAuth != nil {
+		t.Error("expected ActiveAuth to be nil")
+	}
+}
+
+func TestChipAuthEvidenceToCborCA(t *testing.T) {
+	src := &ChipAuthEvidence{
+		TermPri:    []byte{0x01, 0x02},
+		TermPubKey: []byte{0x03, 0x04},
+		SmRapdu:    []byte{0x05, 0x06},
+	}
+
+	session := Session{
+		ChipAuthResult: &ChipAuthResult{Success: true, Evidence: src},
+	}
+
+	cborBytes, err := session.ChipAuthEvidenceToCbor()
+	if err != nil {
+		t.Fatalf("ChipAuthEvidenceToCbor error: %s", err)
+	}
+
+	result, err := NewChipAuthEvidenceFromCbor(cborBytes)
+	if err != nil {
+		t.Fatalf("NewChipAuthEvidenceFromCbor error: %s", err)
+	}
+
+	if result.ChipAuth == nil {
+		t.Fatal("expected ChipAuth evidence to be non-nil")
+	}
+	if !bytes.Equal(result.ChipAuth.TermPri, src.TermPri) {
+		t.Error("TermPri mismatch")
+	}
+	if !bytes.Equal(result.ChipAuth.TermPubKey, src.TermPubKey) {
+		t.Error("TermPubKey mismatch")
+	}
+	if !bytes.Equal(result.ChipAuth.SmRapdu, src.SmRapdu) {
+		t.Error("SmRapdu mismatch")
+	}
+}
+
+func TestChipAuthEvidenceToCborAA(t *testing.T) {
+	src := &ActiveAuthEvidence{
+		Algorithm: asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 2},
+		Nonce:     []byte{0xaa, 0xbb},
+		Signature: []byte{0xcc, 0xdd},
+	}
+
+	session := Session{
+		ActiveAuthResult: &ActiveAuthResult{Success: true, Evidence: src},
+	}
+
+	cborBytes, err := session.ChipAuthEvidenceToCbor()
+	if err != nil {
+		t.Fatalf("ChipAuthEvidenceToCbor error: %s", err)
+	}
+
+	result, err := NewChipAuthEvidenceFromCbor(cborBytes)
+	if err != nil {
+		t.Fatalf("NewChipAuthEvidenceFromCbor error: %s", err)
+	}
+
+	if result.ActiveAuth == nil {
+		t.Fatal("expected ActiveAuth evidence to be non-nil")
+	}
+	if !result.ActiveAuth.Algorithm.Equal(src.Algorithm) {
+		t.Errorf("Algorithm mismatch: want %s, got %s", src.Algorithm, result.ActiveAuth.Algorithm)
+	}
+	if !bytes.Equal(result.ActiveAuth.Nonce, src.Nonce) {
+		t.Error("Nonce mismatch")
+	}
+	if !bytes.Equal(result.ActiveAuth.Signature, src.Signature) {
+		t.Error("Signature mismatch")
+	}
+}
+
+func TestChipAuthEvidenceToCborAllThree(t *testing.T) {
+	srcPaceCam := &PaceCamEvidence{
+		PaceOid:     asn1.ObjectIdentifier{0, 4, 0, 127, 0, 7, 2, 2, 4, 2, 4},
+		ParameterId: 13,
+		Nonce:       []byte{0x01, 0x02, 0x03},
+		TermMapPri:  []byte{0x04, 0x05},
+		ChipMapPub:  []byte{0x06, 0x07},
+		TermKaPri:   []byte{0x08, 0x09},
+		ChipKaPub:   []byte{0x0a, 0x0b},
+		EcadIC:      []byte{0x0c, 0x0d},
+	}
+	srcCA := &ChipAuthEvidence{
+		TermPri:    []byte{0x10, 0x11},
+		TermPubKey: []byte{0x12, 0x13},
+		SmRapdu:    []byte{0x14, 0x15},
+	}
+	srcAA := &ActiveAuthEvidence{
+		Algorithm: asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 2},
+		Nonce:     []byte{0xaa, 0xbb},
+		Signature: []byte{0xcc, 0xdd},
+	}
+
+	session := Session{
+		PaceCamResult:    &PaceCamResult{Success: true, Evidence: srcPaceCam},
+		ChipAuthResult:   &ChipAuthResult{Success: true, Evidence: srcCA},
+		ActiveAuthResult: &ActiveAuthResult{Success: true, Evidence: srcAA},
+	}
+
+	cborBytes, err := session.ChipAuthEvidenceToCbor()
+	if err != nil {
+		t.Fatalf("ChipAuthEvidenceToCbor error: %s", err)
+	}
+
+	result, err := NewChipAuthEvidenceFromCbor(cborBytes)
+	if err != nil {
+		t.Fatalf("NewChipAuthEvidenceFromCbor error: %s", err)
+	}
+
+	if result.PaceCam == nil {
+		t.Fatal("expected PaceCam to be non-nil")
+	}
+	if !result.PaceCam.PaceOid.Equal(srcPaceCam.PaceOid) {
+		t.Errorf("PaceCam.PaceOid mismatch: want %s, got %s", srcPaceCam.PaceOid, result.PaceCam.PaceOid)
+	}
+	if !bytes.Equal(result.PaceCam.Nonce, srcPaceCam.Nonce) {
+		t.Error("PaceCam.Nonce mismatch")
+	}
+
+	if result.ChipAuth == nil {
+		t.Fatal("expected ChipAuth to be non-nil")
+	}
+	if !bytes.Equal(result.ChipAuth.TermPri, srcCA.TermPri) {
+		t.Error("ChipAuth.TermPri mismatch")
+	}
+	if !bytes.Equal(result.ChipAuth.SmRapdu, srcCA.SmRapdu) {
+		t.Error("ChipAuth.SmRapdu mismatch")
+	}
+
+	if result.ActiveAuth == nil {
+		t.Fatal("expected ActiveAuth to be non-nil")
+	}
+	if !result.ActiveAuth.Algorithm.Equal(srcAA.Algorithm) {
+		t.Errorf("ActiveAuth.Algorithm mismatch: want %s, got %s", srcAA.Algorithm, result.ActiveAuth.Algorithm)
+	}
+	if !bytes.Equal(result.ActiveAuth.Signature, srcAA.Signature) {
+		t.Error("ActiveAuth.Signature mismatch")
+	}
+}
+
+func TestChipAuthEvidenceToCborResultWithoutEvidence(t *testing.T) {
+	session := Session{
+		PaceCamResult:    &PaceCamResult{Success: true},
+		ChipAuthResult:   &ChipAuthResult{Success: true},
+		ActiveAuthResult: &ActiveAuthResult{Success: true},
+	}
+
+	cborBytes, err := session.ChipAuthEvidenceToCbor()
+	if err != nil {
+		t.Fatalf("ChipAuthEvidenceToCbor error: %s", err)
+	}
+
+	result, err := NewChipAuthEvidenceFromCbor(cborBytes)
+	if err != nil {
+		t.Fatalf("NewChipAuthEvidenceFromCbor error: %s", err)
+	}
+
+	if result.PaceCam != nil || result.ChipAuth != nil || result.ActiveAuth != nil {
+		t.Error("expected all evidence to be nil when results have no evidence")
+	}
+}
+
+func TestChipAuthEvidenceFromCborInvalidInput(t *testing.T) {
+	_, err := NewChipAuthEvidenceFromCbor([]byte{0xff, 0xff, 0xff})
+	if err == nil {
+		t.Error("expected error for invalid CBOR input")
+	}
+}
+
+func TestChipAuthEvidenceFromCborBadMagic(t *testing.T) {
+	env := cborEnvelope{
+		Magic:   "wrong-magic",
+		Version: chipAuthEvidenceVersion,
+		SHA256:  make([]byte, 32),
+		Payload: []byte{},
+	}
+	data, err := cbor.Marshal(env)
+	if err != nil {
+		t.Fatalf("cbor.Marshal error: %s", err)
+	}
+
+	_, err = NewChipAuthEvidenceFromCbor(data)
+	if err == nil {
+		t.Error("expected error for wrong magic")
+	}
+}
+
+func TestChipAuthEvidenceFromCborUnsupportedVersion(t *testing.T) {
+	payload, _ := cbor.Marshal(cborChipAuthBundle{})
+	env := cborEnvelope{
+		Magic:   chipAuthEvidenceMagic,
+		Version: chipAuthEvidenceVersion + 1,
+		SHA256:  make([]byte, 32),
+		Payload: payload,
+	}
+	data, err := cbor.Marshal(env)
+	if err != nil {
+		t.Fatalf("cbor.Marshal error: %s", err)
+	}
+
+	_, err = NewChipAuthEvidenceFromCbor(data)
+	if err == nil {
+		t.Error("expected error for unsupported version")
+	}
+}
+
+func TestChipAuthEvidenceFromCborChecksumMismatch(t *testing.T) {
+	cborBytes, err := (&Session{}).ChipAuthEvidenceToCbor()
+	if err != nil {
+		t.Fatalf("ChipAuthEvidenceToCbor error: %s", err)
+	}
+
+	var env cborEnvelope
+	if err = cbor.Unmarshal(cborBytes, &env); err != nil {
+		t.Fatalf("cbor.Unmarshal error: %s", err)
+	}
+	env.Payload[0] ^= 0xff
+	corrupted, err := cbor.Marshal(env)
+	if err != nil {
+		t.Fatalf("cbor.Marshal error: %s", err)
+	}
+
+	_, err = NewChipAuthEvidenceFromCbor(corrupted)
+	if err == nil {
+		t.Error("expected checksum mismatch error for corrupted payload")
+	}
+}


### PR DESCRIPTION
## Summary
  - Add `Session.ChipAuthEvidenceToCbor()` and `NewChipAuthEvidenceFromCbor()` for CBOR serialization of chip authentication evidence (PACE-CAM, CA, AA)
  - Uses the same versioned envelope pattern as `Document.ToCbor()` with magic `gmrtd-chip-auth-evidence`, SHA-256 integrity checksum, and version field
  - OIDs stored as `[]int` for lossless round-trip with `asn1.ObjectIdentifier`
  - Empty bundle is valid (passport may not support chip authentication)

  ## Test plan
  - [x] Empty session round-trips correctly (all evidence nil)
  - [x] Each evidence type round-trips independently (PACE-CAM, CA, AA)
  - [x] All three evidence types round-trip simultaneously
  - [x] Results with Success=true but nil Evidence produce empty bundle
  - [x] Invalid CBOR input returns error
  - [x] Wrong magic returns error
  - [x] Unsupported version returns error
  - [x] Corrupted payload (SHA-256 mismatch) returns error