### PR TITLE
feat(document): move ApduLog from Session to DocumentEx

### DIFF
--- a/cmd/gmrtd-reader/templates/output.gohtml
+++ b/cmd/gmrtd-reader/templates/output.gohtml
@@ -868,8 +868,8 @@ document.addEventListener('DOMContentLoaded', () => {
 </div>
 
 <div id="apdu">
-{{ if .Session.ApduLog }}
-{{ template "apduLog" .Session.ApduLog }}
+{{ if .ApduLog }}
+{{ template "apduLog" .ApduLog }}
 {{ end }}
 </div>
 

--- a/document/document_ex.go
+++ b/document/document_ex.go
@@ -3,11 +3,14 @@ package document
 import (
 	"encoding/json"
 	"log"
+
+	"github.com/gmrtd/gmrtd/iso7816"
 )
 
 type DocumentEx struct {
-	Document Document `json:"document"`
-	Session  Session  `json:"session"`
+	Document Document         `json:"document"`
+	Session  Session          `json:"session"`
+	ApduLog  *iso7816.ApduLog `json:"apduLog,omitempty"`
 }
 
 func (docEx *DocumentEx) IndentedJson() string {

--- a/document/session.go
+++ b/document/session.go
@@ -4,8 +4,6 @@ import (
 	"encoding/asn1"
 	"encoding/json"
 	"fmt"
-
-	"github.com/gmrtd/gmrtd/iso7816"
 )
 
 type Session struct {
@@ -34,8 +32,6 @@ type Session struct {
 
 	// Summary (generated from above data)
 	Summary *DocumentSummary `json:"summary,omitempty"`
-
-	ApduLog *iso7816.ApduLog `json:"apduLog,omitempty"`
 }
 
 // ChipAuthProtocolCompleted reports whether a chip authentication protocol (PACE-CAM/CA/AA)

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -156,8 +156,7 @@ func (reader *Reader) ReadDocument(password *password.Password, atr []byte, ats 
 		return state.docEx, fmt.Errorf("[ReadDocument] runSteps error: %w", err)
 	}
 
-	// copy apdu-log over to session
-	state.docEx.Session.ApduLog = reader.nfc.ApduLog()
+	state.docEx.ApduLog = reader.nfc.ApduLog()
 
 	// TODO - should get from summary...
 	reader.status.Status("Valid Document!")


### PR DESCRIPTION
## Summary
 
- Move ApduLog from Session to DocumentEx — the APDU log is an operational artifact of the NFC read, not session state
- Update reader assignment and HTML template references accordingly

## Test plan

- [x] Run go build ./... to verify compilation
- [x] Run go test ./... to verify no regressions
- [x] Read a document with gmrtd-reader and verify the APDU log section still renders correctly in the HTML output
- [x] Verify JSON output has apduLog at the top level of DocumentEx instead of nested under session

**Breaking change: Consumers deserialising DocumentEx JSON will find apduLog at the root level instead of under session.**