### PR TITLE
feat(verifier): add offline document verification and DocumentEx CBOR serialisation

### DIFF
--- a/cmd/gmrtd-reader/main.go
+++ b/cmd/gmrtd-reader/main.go
@@ -86,11 +86,16 @@ func parseDocumentTemplates() (*template.Template, error) {
 	return template.New("").Funcs(templateFuncMap()).ParseFS(templateFS, "templates/*.gohtml")
 }
 
-func executeDocumentTemplate(tmpl *template.Template, documentEx *document.DocumentEx) (*bytes.Buffer, error) {
+type templateData struct {
+	*document.DocumentEx
+	CborBase64 string
+}
+
+func executeDocumentTemplate(tmpl *template.Template, data *templateData) (*bytes.Buffer, error) {
 	byteBuf := bytes.NewBuffer(nil)
 
 	// convert to HTML using template
-	err := tmpl.ExecuteTemplate(byteBuf, "output.gohtml", documentEx)
+	err := tmpl.ExecuteTemplate(byteBuf, "output.gohtml", data)
 	if err != nil {
 		return nil, fmt.Errorf("[generateDocument] ExecuteTemplate error: %w", err)
 	}
@@ -110,7 +115,16 @@ func generateDocument(documentEx *document.DocumentEx) (*bytes.Buffer, error) {
 		return nil, fmt.Errorf("[generateDocument] ParseFS error: %w", err)
 	}
 
-	byteBuf, err := executeDocumentTemplate(tmpl, documentEx)
+	data := &templateData{DocumentEx: documentEx}
+
+	cborBytes, err := documentEx.ToCbor()
+	if err != nil {
+		slog.Warn("ToCbor failed, CBOR section will be unavailable", "error", err)
+	} else {
+		data.CborBase64 = base64.StdEncoding.EncodeToString(cborBytes)
+	}
+
+	byteBuf, err := executeDocumentTemplate(tmpl, data)
 	if err != nil {
 		return nil, fmt.Errorf("[generateDocument] executeDocumentTemplate error: %w", err)
 	}

--- a/cmd/gmrtd-reader/main_test.go
+++ b/cmd/gmrtd-reader/main_test.go
@@ -242,7 +242,7 @@ func TestGenerateDocumentNilDocument(t *testing.T) {
 func TestExecuteDocumentTemplateError(t *testing.T) {
 	tmpl := template.Must(template.New("not-output").Parse(`hello`))
 
-	out, err := executeDocumentTemplate(tmpl, &document.DocumentEx{})
+	out, err := executeDocumentTemplate(tmpl, &templateData{DocumentEx: &document.DocumentEx{}})
 	if err == nil {
 		t.Fatalf("expected error")
 	}

--- a/cmd/gmrtd-reader/templates/output.gohtml
+++ b/cmd/gmrtd-reader/templates/output.gohtml
@@ -594,7 +594,7 @@ document.addEventListener('DOMContentLoaded', () => {
 <h1><a href="https://github.com/gmrtd/gmrtd">GMRTD</a> <sub>(v{{ GmrtdVersion }})</sub></h1>
 
 <div>
-<a href="#session">Session</a> | <a href="#document">Document</a> | <a href="#apdu">APDU</a> | <a href="#json">JSON</a>
+<a href="#session">Session</a> | <a href="#document">Document</a> | <a href="#apdu">APDU</a> | <a href="#json">JSON</a> | <a href="#cbor">CBOR</a>
 </div>
 
 <br/>
@@ -879,6 +879,84 @@ document.addEventListener('DOMContentLoaded', () => {
 <div><pre>
 {{ .IndentedJson }}
 </pre></div>
+</div>
+
+<div id="cbor">
+<h1>CBOR DocumentEx</h1>
+
+{{if .CborBase64}}
+<div class="raw-block" data-expanded="false">
+  <div class="raw-toolbar">
+    <div class="raw-meta" id="cbor-meta"></div>
+    <div class="raw-actions">
+      <button class="btn" type="button" id="cbor-toggle">Expand</button>
+      <button class="btn" type="button" id="cbor-copy-hex">Copy hex</button>
+      <button class="btn" type="button" id="cbor-copy-b64">Copy base64</button>
+      <button class="btn" type="button" id="cbor-download">Download .cbor</button>
+    </div>
+    <span class="copy-status" id="cbor-status"></span>
+  </div>
+  <div class="raw-preview">
+    <div class="hex-data" id="cbor-preview"></div>
+  </div>
+  <div class="raw-full">
+    <div class="hex-data" id="cbor-full"></div>
+  </div>
+</div>
+
+<script>
+(function() {
+  var b64 = "{{ .CborBase64 }}";
+  var raw = atob(b64);
+  var bytes = new Uint8Array(raw.length);
+  for (var i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
+
+  var hex = Array.from(bytes, function(b) { return ('0'+b.toString(16)).slice(-2); }).join('');
+  var spaced = hex.match(/.{2}/g).join(' ');
+
+  document.getElementById('cbor-meta').textContent = bytes.length.toLocaleString() + ' bytes';
+
+  var PREVIEW_BYTES = 64;
+  var previewHex = hex.slice(0, PREVIEW_BYTES * 2);
+  document.getElementById('cbor-preview').textContent = previewHex.match(/.{2}/g).join(' ') + ' …';
+  document.getElementById('cbor-full').textContent = spaced;
+
+  var block = document.getElementById('cbor-toggle').closest('.raw-block');
+
+  document.getElementById('cbor-toggle').addEventListener('click', function() {
+    var expanded = block.dataset.expanded === 'true';
+    block.dataset.expanded = expanded ? 'false' : 'true';
+    this.textContent = expanded ? 'Expand' : 'Collapse';
+  });
+
+  var statusEl = document.getElementById('cbor-status');
+  function setStatus(msg) {
+    statusEl.textContent = msg;
+    if (msg) setTimeout(function() { statusEl.textContent = ''; }, 900);
+  }
+
+  document.getElementById('cbor-copy-hex').addEventListener('click', function() {
+    navigator.clipboard.writeText(hex).then(function() { setStatus('Copied hex'); }, function() { setStatus('Copy failed'); });
+  });
+
+  document.getElementById('cbor-copy-b64').addEventListener('click', function() {
+    navigator.clipboard.writeText(b64).then(function() { setStatus('Copied base64'); }, function() { setStatus('Copy failed'); });
+  });
+
+  document.getElementById('cbor-download').addEventListener('click', function() {
+    var blob = new Blob([bytes], { type: 'application/cbor' });
+    var a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'gmrtd-verifiable-doc.cbor';
+    a.click();
+    URL.revokeObjectURL(a.href);
+    setStatus('Downloaded');
+  });
+})();
+</script>
+{{else}}
+<i>CBOR data not available</i>
+{{end}}
 </div>
 
 </body>

--- a/document/document_ex.go
+++ b/document/document_ex.go
@@ -13,6 +13,16 @@ type DocumentEx struct {
 	ApduLog  *iso7816.ApduLog `json:"apduLog,omitempty"`
 }
 
+func (docEx *DocumentEx) GenerateSummary() {
+	docEx.Session.Summary = &DocumentSummary{
+		DataTrusted: docEx.Session.PassiveAuthResult != nil &&
+			docEx.Session.PassiveAuthResult.Success,
+		ChipAuthenticity: docEx.Session.VerifiedChipAuthStatus(),
+		LdsVersion:       docEx.Document.LdsVersion(),
+		UnicodeVersion:   docEx.Document.UnicodeVersion(),
+	}
+}
+
 func (docEx *DocumentEx) IndentedJson() string {
 	b, err := json.MarshalIndent(docEx, "", "    ")
 	if err != nil {

--- a/document/document_ex_cbor.go
+++ b/document/document_ex_cbor.go
@@ -1,0 +1,85 @@
+package document
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+
+	cbor "github.com/fxamacker/cbor/v2"
+)
+
+type rawDocumentEx struct {
+	Document         []byte `cbor:"document"`
+	ChipAuthEvidence []byte `cbor:"chipAuthEvidence"`
+}
+
+const documentExMagic = "gmrtd-verifiable-doc"
+const documentExVersion uint = 1
+
+func (docEx *DocumentEx) ToCbor() ([]byte, error) {
+	docBytes, err := docEx.Document.ToCbor()
+	if err != nil {
+		return nil, fmt.Errorf("[DocumentEx.ToCbor] Document.ToCbor error: %w", err)
+	}
+
+	caBytes, err := docEx.Session.ChipAuthEvidenceToCbor()
+	if err != nil {
+		return nil, fmt.Errorf("[DocumentEx.ToCbor] ChipAuthEvidenceToCbor error: %w", err)
+	}
+
+	raw := rawDocumentEx{
+		Document:         docBytes,
+		ChipAuthEvidence: caBytes,
+	}
+
+	payload, err := cbor.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("[DocumentEx.ToCbor] cbor.Marshal(rawDocumentEx) error: %w", err)
+	}
+
+	digest := sha256.Sum256(payload)
+	env := cborEnvelope{
+		Magic:   documentExMagic,
+		Version: documentExVersion,
+		SHA256:  digest[:],
+		Payload: payload,
+	}
+
+	return cbor.Marshal(env)
+}
+
+func UnmarshalVerifiableDoc(data []byte) (*Document, *ChipAuthEvidenceBundle, error) {
+	var env cborEnvelope
+	if err := cbor.Unmarshal(data, &env); err != nil {
+		return nil, nil, fmt.Errorf("[UnmarshalVerifiableDoc] cbor.Unmarshal(envelope) error: %w", err)
+	}
+
+	if env.Magic != documentExMagic {
+		return nil, nil, fmt.Errorf("[UnmarshalVerifiableDoc] unrecognised magic %q (want %q)", env.Magic, documentExMagic)
+	}
+	if env.Version > documentExVersion {
+		return nil, nil, fmt.Errorf("[UnmarshalVerifiableDoc] unsupported version %d (max supported: %d)", env.Version, documentExVersion)
+	}
+
+	digest := sha256.Sum256(env.Payload)
+	if !bytes.Equal(digest[:], env.SHA256) {
+		return nil, nil, fmt.Errorf("[UnmarshalVerifiableDoc] SHA-256 checksum mismatch: payload is corrupt")
+	}
+
+	var raw rawDocumentEx
+	if err := cbor.Unmarshal(env.Payload, &raw); err != nil {
+		return nil, nil, fmt.Errorf("[UnmarshalVerifiableDoc] cbor.Unmarshal(rawDocumentEx) error: %w", err)
+	}
+
+	doc, err := NewDocumentFromCbor(raw.Document)
+	if err != nil {
+		return nil, nil, fmt.Errorf("[UnmarshalVerifiableDoc] NewDocumentFromCbor error: %w", err)
+	}
+
+	caBundle, err := NewChipAuthEvidenceFromCbor(raw.ChipAuthEvidence)
+	if err != nil {
+		return nil, nil, fmt.Errorf("[UnmarshalVerifiableDoc] NewChipAuthEvidenceFromCbor error: %w", err)
+	}
+
+	return doc, caBundle, nil
+}

--- a/document/document_ex_cbor_test.go
+++ b/document/document_ex_cbor_test.go
@@ -1,0 +1,292 @@
+package document
+
+import (
+	"bytes"
+	"encoding/asn1"
+	"testing"
+
+	cbor "github.com/fxamacker/cbor/v2"
+)
+
+func TestDocumentExToCbor(t *testing.T) {
+	var docEx DocumentEx
+	var err error
+
+	docEx.Document.Mf.Lds1.Dg1, err = NewDG1(dg1TestVector)
+	if err != nil {
+		t.Fatalf("NewDG1 error: %s", err)
+	}
+
+	docEx.Session.PaceCamResult = &PaceCamResult{
+		Success: true,
+		Evidence: &PaceCamEvidence{
+			PaceOid:     asn1.ObjectIdentifier{0, 4, 0, 127, 0, 7, 2, 2, 4, 2, 4},
+			ParameterId: 13,
+			Nonce:       []byte{0x01, 0x02, 0x03},
+			TermMapPri:  []byte{0x04, 0x05},
+			ChipMapPub:  []byte{0x06, 0x07},
+			TermKaPri:   []byte{0x08, 0x09},
+			ChipKaPub:   []byte{0x0a, 0x0b},
+			EcadIC:      []byte{0x0c, 0x0d},
+		},
+	}
+
+	cborBytes, err := docEx.ToCbor()
+	if err != nil {
+		t.Fatalf("ToCbor error: %s", err)
+	}
+	if len(cborBytes) == 0 {
+		t.Fatal("ToCbor returned empty bytes")
+	}
+
+	var env cborEnvelope
+	if err = cbor.Unmarshal(cborBytes, &env); err != nil {
+		t.Fatalf("cbor.Unmarshal(envelope) error: %s", err)
+	}
+	if env.Magic != documentExMagic {
+		t.Errorf("magic mismatch: want %q, got %q", documentExMagic, env.Magic)
+	}
+}
+
+func TestDocumentExRoundTrip(t *testing.T) {
+	var src DocumentEx
+	var err error
+
+	src.Document.Mf.Lds1.Dg1, err = NewDG1(dg1TestVector)
+	if err != nil {
+		t.Fatalf("NewDG1 error: %s", err)
+	}
+	src.Document.Mf.Lds1.Com, err = NewCOM(comTestVector)
+	if err != nil {
+		t.Fatalf("NewCOM error: %s", err)
+	}
+
+	src.Session.ChipAuthResult = &ChipAuthResult{
+		Success: true,
+		Evidence: &ChipAuthEvidence{
+			TermPri:    []byte{0x01, 0x02},
+			TermPubKey: []byte{0x03, 0x04},
+			SmRapdu:    []byte{0x05, 0x06},
+		},
+	}
+
+	cborBytes, err := src.ToCbor()
+	if err != nil {
+		t.Fatalf("ToCbor error: %s", err)
+	}
+
+	doc, caBundle, err := UnmarshalVerifiableDoc(cborBytes)
+	if err != nil {
+		t.Fatalf("UnmarshalVerifiableDoc error: %s", err)
+	}
+
+	if doc.Mf.Lds1.Dg1 == nil {
+		t.Fatal("expected Dg1 to be non-nil after round-trip")
+	}
+	if !bytes.Equal(doc.Mf.Lds1.Dg1.RawData, dg1TestVector) {
+		t.Errorf("Dg1.RawData mismatch\n  want: %x\n   got: %x", dg1TestVector, doc.Mf.Lds1.Dg1.RawData)
+	}
+
+	if doc.Mf.Lds1.Com == nil {
+		t.Fatal("expected Com to be non-nil after round-trip")
+	}
+	if !bytes.Equal(doc.Mf.Lds1.Com.RawData, comTestVector) {
+		t.Errorf("Com.RawData mismatch\n  want: %x\n   got: %x", comTestVector, doc.Mf.Lds1.Com.RawData)
+	}
+
+	if caBundle.ChipAuth == nil {
+		t.Fatal("expected ChipAuth evidence to be non-nil after round-trip")
+	}
+	if !bytes.Equal(caBundle.ChipAuth.TermPri, []byte{0x01, 0x02}) {
+		t.Error("ChipAuth.TermPri mismatch")
+	}
+	if !bytes.Equal(caBundle.ChipAuth.TermPubKey, []byte{0x03, 0x04}) {
+		t.Error("ChipAuth.TermPubKey mismatch")
+	}
+	if !bytes.Equal(caBundle.ChipAuth.SmRapdu, []byte{0x05, 0x06}) {
+		t.Error("ChipAuth.SmRapdu mismatch")
+	}
+}
+
+func TestDocumentExRoundTripEmpty(t *testing.T) {
+	cborBytes, err := (&DocumentEx{}).ToCbor()
+	if err != nil {
+		t.Fatalf("ToCbor error: %s", err)
+	}
+
+	doc, caBundle, err := UnmarshalVerifiableDoc(cborBytes)
+	if err != nil {
+		t.Fatalf("UnmarshalVerifiableDoc error: %s", err)
+	}
+	if doc == nil {
+		t.Fatal("expected non-nil Document for empty CBOR")
+	}
+
+	if doc.Mf.Lds1.Dg1 != nil {
+		t.Error("expected Dg1 to be nil for empty document")
+	}
+	if caBundle.PaceCam != nil {
+		t.Error("expected PaceCam to be nil for empty session")
+	}
+	if caBundle.ChipAuth != nil {
+		t.Error("expected ChipAuth to be nil for empty session")
+	}
+	if caBundle.ActiveAuth != nil {
+		t.Error("expected ActiveAuth to be nil for empty session")
+	}
+}
+
+func TestDocumentExRoundTripPaceCam(t *testing.T) {
+	var src DocumentEx
+
+	src.Session.PaceCamResult = &PaceCamResult{
+		Success: true,
+		Evidence: &PaceCamEvidence{
+			PaceOid:     asn1.ObjectIdentifier{0, 4, 0, 127, 0, 7, 2, 2, 4, 2, 4},
+			ParameterId: 13,
+			Nonce:       []byte{0x01, 0x02, 0x03},
+			TermMapPri:  []byte{0x04, 0x05},
+			ChipMapPub:  []byte{0x06, 0x07},
+			TermKaPri:   []byte{0x08, 0x09},
+			ChipKaPub:   []byte{0x0a, 0x0b},
+			EcadIC:      []byte{0x0c, 0x0d},
+		},
+	}
+
+	cborBytes, err := src.ToCbor()
+	if err != nil {
+		t.Fatalf("ToCbor error: %s", err)
+	}
+
+	_, caBundle, err := UnmarshalVerifiableDoc(cborBytes)
+	if err != nil {
+		t.Fatalf("UnmarshalVerifiableDoc error: %s", err)
+	}
+
+	if caBundle.PaceCam == nil {
+		t.Fatal("expected PaceCam evidence to be non-nil")
+	}
+	if !caBundle.PaceCam.PaceOid.Equal(asn1.ObjectIdentifier{0, 4, 0, 127, 0, 7, 2, 2, 4, 2, 4}) {
+		t.Error("PaceCam.PaceOid mismatch")
+	}
+	if !bytes.Equal(caBundle.PaceCam.Nonce, []byte{0x01, 0x02, 0x03}) {
+		t.Error("PaceCam.Nonce mismatch")
+	}
+	if !bytes.Equal(caBundle.PaceCam.EcadIC, []byte{0x0c, 0x0d}) {
+		t.Error("PaceCam.EcadIC mismatch")
+	}
+	if caBundle.ChipAuth != nil {
+		t.Error("expected ChipAuth to be nil")
+	}
+	if caBundle.ActiveAuth != nil {
+		t.Error("expected ActiveAuth to be nil")
+	}
+}
+
+func TestDocumentExRoundTripAA(t *testing.T) {
+	var src DocumentEx
+
+	src.Session.ActiveAuthResult = &ActiveAuthResult{
+		Success: true,
+		Evidence: &ActiveAuthEvidence{
+			Algorithm: asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 2},
+			Nonce:     []byte{0xaa, 0xbb},
+			Signature: []byte{0xcc, 0xdd},
+		},
+	}
+
+	cborBytes, err := src.ToCbor()
+	if err != nil {
+		t.Fatalf("ToCbor error: %s", err)
+	}
+
+	_, caBundle, err := UnmarshalVerifiableDoc(cborBytes)
+	if err != nil {
+		t.Fatalf("UnmarshalVerifiableDoc error: %s", err)
+	}
+
+	if caBundle.ActiveAuth == nil {
+		t.Fatal("expected ActiveAuth evidence to be non-nil")
+	}
+	if !caBundle.ActiveAuth.Algorithm.Equal(asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 2}) {
+		t.Error("ActiveAuth.Algorithm mismatch")
+	}
+	if !bytes.Equal(caBundle.ActiveAuth.Nonce, []byte{0xaa, 0xbb}) {
+		t.Error("ActiveAuth.Nonce mismatch")
+	}
+	if !bytes.Equal(caBundle.ActiveAuth.Signature, []byte{0xcc, 0xdd}) {
+		t.Error("ActiveAuth.Signature mismatch")
+	}
+	if caBundle.PaceCam != nil {
+		t.Error("expected PaceCam to be nil")
+	}
+	if caBundle.ChipAuth != nil {
+		t.Error("expected ChipAuth to be nil")
+	}
+}
+
+func TestDocumentExFromCborInvalidInput(t *testing.T) {
+	_, _, err := UnmarshalVerifiableDoc([]byte{0xff, 0xff, 0xff})
+	if err == nil {
+		t.Error("expected error for invalid CBOR input")
+	}
+}
+
+func TestDocumentExFromCborBadMagic(t *testing.T) {
+	env := cborEnvelope{
+		Magic:   "wrong-magic",
+		Version: documentExVersion,
+		SHA256:  make([]byte, 32),
+		Payload: []byte{},
+	}
+	data, err := cbor.Marshal(env)
+	if err != nil {
+		t.Fatalf("cbor.Marshal error: %s", err)
+	}
+
+	_, _, err = UnmarshalVerifiableDoc(data)
+	if err == nil {
+		t.Error("expected error for wrong magic")
+	}
+}
+
+func TestDocumentExFromCborUnsupportedVersion(t *testing.T) {
+	payload, _ := cbor.Marshal(rawDocumentEx{})
+	env := cborEnvelope{
+		Magic:   documentExMagic,
+		Version: documentExVersion + 1,
+		SHA256:  make([]byte, 32),
+		Payload: payload,
+	}
+	data, err := cbor.Marshal(env)
+	if err != nil {
+		t.Fatalf("cbor.Marshal error: %s", err)
+	}
+
+	_, _, err = UnmarshalVerifiableDoc(data)
+	if err == nil {
+		t.Error("expected error for unsupported version")
+	}
+}
+
+func TestDocumentExFromCborChecksumMismatch(t *testing.T) {
+	cborBytes, err := (&DocumentEx{}).ToCbor()
+	if err != nil {
+		t.Fatalf("ToCbor error: %s", err)
+	}
+
+	var env cborEnvelope
+	if err = cbor.Unmarshal(cborBytes, &env); err != nil {
+		t.Fatalf("cbor.Unmarshal error: %s", err)
+	}
+	env.Payload[0] ^= 0xff
+	corrupted, err := cbor.Marshal(env)
+	if err != nil {
+		t.Fatalf("cbor.Marshal error: %s", err)
+	}
+
+	_, _, err = UnmarshalVerifiableDoc(corrupted)
+	if err == nil {
+		t.Error("expected checksum mismatch error for corrupted payload")
+	}
+}

--- a/document/document_ex_test.go
+++ b/document/document_ex_test.go
@@ -1,0 +1,81 @@
+package document
+
+import "testing"
+
+func TestGenerateSummaryPassiveAuthSuccess(t *testing.T) {
+	docEx := &DocumentEx{
+		Session: Session{
+			ChipAuthResult:    &ChipAuthResult{Success: true},
+			PassiveAuthResult: &PassiveAuthResult{Success: true, Sod: NewPassiveAuth(nil)},
+		},
+	}
+
+	docEx.GenerateSummary()
+
+	if docEx.Session.Summary == nil {
+		t.Fatal("expected Summary to be non-nil")
+	}
+	if !docEx.Session.Summary.DataTrusted {
+		t.Error("expected DataTrusted to be true")
+	}
+	if docEx.Session.Summary.ChipAuthenticity != CHIP_AUTH_STATUS_CA {
+		t.Errorf("expected ChipAuthenticity CA, got %d", docEx.Session.Summary.ChipAuthenticity)
+	}
+}
+
+func TestGenerateSummaryPassiveAuthFail(t *testing.T) {
+	docEx := &DocumentEx{
+		Session: Session{
+			ChipAuthResult:    &ChipAuthResult{Success: true},
+			PassiveAuthResult: &PassiveAuthResult{Success: false},
+		},
+	}
+
+	docEx.GenerateSummary()
+
+	if docEx.Session.Summary == nil {
+		t.Fatal("expected Summary to be non-nil")
+	}
+	if docEx.Session.Summary.DataTrusted {
+		t.Error("expected DataTrusted to be false")
+	}
+	if docEx.Session.Summary.ChipAuthenticity != CHIP_AUTH_STATUS_NONE {
+		t.Errorf("expected ChipAuthenticity NONE, got %d", docEx.Session.Summary.ChipAuthenticity)
+	}
+}
+
+func TestGenerateSummaryNoPassiveAuth(t *testing.T) {
+	docEx := &DocumentEx{
+		Session: Session{
+			ChipAuthResult: &ChipAuthResult{Success: true},
+		},
+	}
+
+	docEx.GenerateSummary()
+
+	if docEx.Session.Summary == nil {
+		t.Fatal("expected Summary to be non-nil")
+	}
+	if docEx.Session.Summary.DataTrusted {
+		t.Error("expected DataTrusted to be false when no PassiveAuthResult")
+	}
+	if docEx.Session.Summary.ChipAuthenticity != CHIP_AUTH_STATUS_NONE {
+		t.Errorf("expected ChipAuthenticity NONE, got %d", docEx.Session.Summary.ChipAuthenticity)
+	}
+}
+
+func TestGenerateSummaryEmpty(t *testing.T) {
+	docEx := &DocumentEx{}
+
+	docEx.GenerateSummary()
+
+	if docEx.Session.Summary == nil {
+		t.Fatal("expected Summary to be non-nil")
+	}
+	if docEx.Session.Summary.DataTrusted {
+		t.Error("expected DataTrusted to be false")
+	}
+	if docEx.Session.Summary.ChipAuthenticity != CHIP_AUTH_STATUS_NONE {
+		t.Errorf("expected ChipAuthenticity NONE, got %d", docEx.Session.Summary.ChipAuthenticity)
+	}
+}

--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime/debug"
+	"sync"
 
 	"github.com/gmrtd/gmrtd/cms"
 	"github.com/gmrtd/gmrtd/document"
@@ -14,7 +15,28 @@ import (
 	"github.com/gmrtd/gmrtd/oid"
 	"github.com/gmrtd/gmrtd/password"
 	"github.com/gmrtd/gmrtd/reader"
+	"github.com/gmrtd/gmrtd/verifier"
 )
+
+var (
+	cscaOnce     sync.Once
+	cscaCertPool cms.CertPool
+	cscaInitErr  error
+)
+
+func PreloadCscaCertPool() error {
+	cscaOnce.Do(func() {
+		cscaCertPool, cscaInitErr = cms.DefaultMasterList()
+	})
+	return cscaInitErr
+}
+
+func getCscaCertPool() (cms.CertPool, error) {
+	if err := PreloadCscaCertPool(); err != nil {
+		return nil, err
+	}
+	return cscaCertPool, nil
+}
 
 // bind doesn't like referencing iso7816.Transceiver
 // so we redefine the interface here
@@ -64,30 +86,12 @@ func NewPasswordCan(can string) (*MrtdPassword, error) {
 	return &MrtdPassword{password: password.NewPasswordCan(can)}, nil
 }
 
-// CscaMasterList holds a pre-initialised CSCA trust store for use with Reader.
-// Callers can create one via NewDefaultCscaMasterList and pass it to
-// Reader.SetCscaMasterList to avoid the initialisation cost inside ReadDocument.
-type CscaMasterList struct {
-	certPool cms.CertPool
-}
-
-// NewDefaultCscaMasterList builds a CscaMasterList from the bundled default
-// master lists (DE, NL, and Indonesian 2010-series certificates).
-func NewDefaultCscaMasterList() (*CscaMasterList, error) {
-	certPool, err := cms.DefaultMasterList()
-	if err != nil {
-		return nil, fmt.Errorf("[NewDefaultCscaMasterList] error: %w", err)
-	}
-	return &CscaMasterList{certPool: certPool}, nil
-}
-
 type Reader struct {
-	status       ReaderStatus
-	transceiver  Transceiver
-	maxRead      int
-	skipPace     bool
-	skipImages   bool
-	cscaCertPool cms.CertPool
+	status      ReaderStatus
+	transceiver Transceiver
+	maxRead     int
+	skipPace    bool
+	skipImages  bool
 }
 
 type Document struct {
@@ -120,29 +124,6 @@ func (r *Reader) SkipImages() {
 	r.skipImages = true
 }
 
-// SetCscaMasterList sets a pre-initialised trust store on the reader.
-// When set, ReadDocument uses this pool directly instead of initialising
-// one itself. Callers can use this to amortise the initialisation cost
-// across multiple ReadDocument calls.
-func (r *Reader) SetCscaMasterList(ml *CscaMasterList) {
-	if ml != nil {
-		r.cscaCertPool = ml.certPool
-	}
-}
-
-func cscaMasterList() (cms.CertPool, error) {
-	var cscaCertPool cms.CertPool
-	var err error
-
-	cscaCertPool, err = cms.DefaultMasterList()
-	if err != nil {
-		return nil, fmt.Errorf("[cscaMasterList] cms.DefaultMasterList error: %w", err)
-	}
-
-	return cscaCertPool, nil
-}
-
-// reads the document (and performs passive authentication)
 func (r *Reader) ReadDocument(password *MrtdPassword, atr []byte, ats []byte) (doc *Document, err error) {
 	defer func() {
 		if e := recover(); e != nil {
@@ -166,15 +147,13 @@ func (r *Reader) ReadDocument(password *MrtdPassword, atr []byte, ats []byte) (d
 		nfc.SetMaxLe(r.maxRead)
 	}
 
-	if r.cscaCertPool == nil {
-		r.cscaCertPool, err = cscaMasterList()
-		if err != nil {
-			return nil, fmt.Errorf("[ReadDocument] cscaMasterList error: %w", err)
-		}
+	certPool, err := getCscaCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("[ReadDocument] getCscaCertPool error: %w", err)
 	}
 
 	var gmrtdReader *reader.Reader
-	gmrtdReader = reader.NewReader(r.status, nfc, r.cscaCertPool)
+	gmrtdReader = reader.NewReader(r.status, nfc, certPool)
 
 	if r.skipPace {
 		gmrtdReader.SkipPace()
@@ -184,7 +163,6 @@ func (r *Reader) ReadDocument(password *MrtdPassword, atr []byte, ats []byte) (d
 		gmrtdReader.SkipImages()
 	}
 
-	// read (and verify) the document (inc passive-authentication)
 	doc.documentEx, err = gmrtdReader.ReadDocument(password.password, atr, ats)
 
 	return doc, err
@@ -212,6 +190,26 @@ func OidDesc(oidStr string) string {
 	return oid.OidDescStr(oidStr)
 }
 
+type Verifier struct{}
+
+func NewVerifier() *Verifier {
+	return &Verifier{}
+}
+
+func (v *Verifier) Verify(data []byte) (doc *Document, err error) {
+	certPool, err := getCscaCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("[Verify] getCscaCertPool error: %w", err)
+	}
+
+	docEx, err := verifier.NewVerifier(certPool).Verify(data)
+	if err != nil {
+		return nil, fmt.Errorf("[Verify] verifier error: %w", err)
+	}
+
+	return &Document{documentEx: docEx}, nil
+}
+
 func (doc *Document) DocumentExJson() (jsonData []byte, err error) {
 	if doc.documentEx == nil {
 		return nil, fmt.Errorf("[DocumentJson] No document available")
@@ -220,4 +218,12 @@ func (doc *Document) DocumentExJson() (jsonData []byte, err error) {
 	jsonData, err = json.Marshal(doc.documentEx)
 
 	return jsonData, err
+}
+
+func (doc *Document) DocumentExCbor() (cborData []byte, err error) {
+	if doc.documentEx == nil {
+		return nil, fmt.Errorf("[DocumentExCbor] No document available")
+	}
+
+	return doc.documentEx.ToCbor()
 }

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/gmrtd/gmrtd/document"
 	"github.com/gmrtd/gmrtd/iso7816"
 )
 
@@ -191,41 +192,50 @@ func TestReadDocument(t *testing.T) {
 	}
 }
 
-func TestNewDefaultCscaMasterList(t *testing.T) {
-	ml, err := NewDefaultCscaMasterList()
+func TestGetCscaCertPool(t *testing.T) {
+	certPool, err := getCscaCertPool()
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if ml == nil {
-		t.Fatalf("expected non-nil CscaMasterList")
-	}
-	if ml.certPool == nil {
+	if certPool == nil {
 		t.Fatalf("expected non-nil certPool")
 	}
 }
 
-func TestSetCscaMasterList(t *testing.T) {
-	ml, err := NewDefaultCscaMasterList()
+func TestPreloadCscaCertPool(t *testing.T) {
+	err := PreloadCscaCertPool()
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
+}
 
-	r := &Reader{}
-	if r.cscaCertPool != nil {
-		t.Fatalf("cscaCertPool should be nil initially")
-	}
+func TestDocumentExCborError(t *testing.T) {
+	doc := &Document{}
 
-	r.SetCscaMasterList(ml)
-	if r.cscaCertPool == nil {
-		t.Fatalf("cscaCertPool should be set after SetCscaMasterList")
+	_, err := doc.DocumentExCbor()
+	if err == nil {
+		t.Error("expected error when documentEx is nil")
 	}
 }
 
-func TestSetCscaMasterListNil(t *testing.T) {
-	r := &Reader{}
-	r.SetCscaMasterList(nil)
-	if r.cscaCertPool != nil {
-		t.Fatalf("cscaCertPool should remain nil when nil is passed")
+func TestDocumentExCborRoundTrip(t *testing.T) {
+	doc := &Document{documentEx: &document.DocumentEx{}}
+
+	cborData, err := doc.DocumentExCbor()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(cborData) == 0 {
+		t.Fatal("expected non-empty CBOR data")
+	}
+}
+
+func TestVerifierVerifyInvalidInput(t *testing.T) {
+	v := NewVerifier()
+
+	_, err := v.Verify([]byte{0xff, 0xff, 0xff})
+	if err == nil {
+		t.Error("expected error for invalid CBOR input")
 	}
 }
 

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -379,13 +379,6 @@ func verifyDocument(reader *Reader, state *ReaderState) (err error) {
 }
 
 func calculateDocumentSummary(_ *Reader, state *ReaderState) error {
-	state.docEx.Session.Summary = &document.DocumentSummary{
-		DataTrusted: state.docEx.Session.PassiveAuthResult != nil &&
-			state.docEx.Session.PassiveAuthResult.Success,
-		ChipAuthenticity: state.docEx.Session.VerifiedChipAuthStatus(),
-		LdsVersion:       state.docEx.Document.LdsVersion(),
-		UnicodeVersion:   state.docEx.Document.UnicodeVersion(),
-	}
-
+	state.docEx.GenerateSummary()
 	return nil
 }

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -1,0 +1,49 @@
+// Package verifier provides offline verification of machine-readable travel documents (MRTDs)
+// by replaying serialised chip authentication evidence and performing passive authentication
+// against a CSCA certificate pool.
+package verifier
+
+import (
+	"fmt"
+
+	"github.com/gmrtd/gmrtd/activeauth"
+	"github.com/gmrtd/gmrtd/chipauth"
+	"github.com/gmrtd/gmrtd/cms"
+	"github.com/gmrtd/gmrtd/document"
+	"github.com/gmrtd/gmrtd/pace"
+	"github.com/gmrtd/gmrtd/passiveauth"
+)
+
+type Verifier struct {
+	cscaCertPool cms.CertPool
+}
+
+func NewVerifier(cscaCertPool cms.CertPool) *Verifier {
+	return &Verifier{cscaCertPool: cscaCertPool}
+}
+
+func (v *Verifier) Verify(data []byte) (*document.DocumentEx, error) {
+	doc, caBundle, err := document.UnmarshalVerifiableDoc(data)
+	if err != nil {
+		return nil, fmt.Errorf("[Verify] UnmarshalVerifiableDoc error: %w", err)
+	}
+
+	var docEx document.DocumentEx
+	docEx.Document = *doc
+
+	if caBundle.PaceCam != nil {
+		docEx.Session.PaceCamResult, docEx.Session.PaceErr = pace.VerifyEvidence(doc, caBundle.PaceCam)
+	}
+	if caBundle.ChipAuth != nil {
+		docEx.Session.ChipAuthResult, docEx.Session.ChipAuthErr = chipauth.VerifyEvidence(doc, caBundle.ChipAuth)
+	}
+	if caBundle.ActiveAuth != nil {
+		docEx.Session.ActiveAuthResult, docEx.Session.ActiveAuthErr = activeauth.VerifyEvidence(doc, caBundle.ActiveAuth)
+	}
+
+	docEx.Session.PassiveAuthResult, docEx.Session.PassiveAuthErr = passiveauth.PassiveAuth(doc, v.cscaCertPool)
+
+	docEx.GenerateSummary()
+
+	return &docEx, nil
+}

--- a/verifier/verifier_test.go
+++ b/verifier/verifier_test.go
@@ -1,0 +1,1 @@
+package verifier


### PR DESCRIPTION
## Summary
  - Add `verifier` package for offline MRTD verification by replaying serialised chip authentication evidence (PACE-CAM, CA, AA) and running passive authentication against a CSCA certificate pool
  - Add CBOR serialisation for `DocumentEx` (`ToCbor` / `UnmarshalVerifiableDoc`) with a versioned, SHA-256-integrity-checked envelope format
  - Move `GenerateSummary` from `reader` into `DocumentEx` so it can be reused by both the reader and the verifier
  - Simplify CSCA cert pool management in `mobile` with thread-safe `sync.Once` lazy initialisation
  - Expose `Verifier` and `DocumentExCbor()` in the `mobile` package for mobile bindings

  ## Breaking changes
  - **Removed `mobile.CscaMasterList` type** and `mobile.NewDefaultCscaMasterList()` — replaced by `mobile.PreloadCscaCertPool()` which uses `sync.Once` for thread-safe lazy initialisation
  - **Removed `mobile.Reader.SetCscaMasterList()`** — the CSCA cert pool is now managed internally; callers no longer need to pass it to the reader
  - **Removed `mobile.Reader.cscaCertPool` field** — the `Reader` struct no longer holds a cert pool reference

  ### Migration
  ```go
  // Before
  ml, _ := mobile.NewDefaultCscaMasterList()
  reader.SetCscaMasterList(ml)

  // After
  mobile.PreloadCscaCertPool() // optional, for eager init
  // reader handles cert pool internally

  Test plan
  
  - [x] go test ./document/... — GenerateSummary, DocumentEx CBOR round-trip, envelope validation (bad magic, unsupported version, checksum mismatch)
  - [x] go test ./mobile/... — getCscaCertPool, PreloadCscaCertPool, Verifier.Verify, DocumentExCbor
  - [x] go test ./reader/... — calculateDocumentSummary via GenerateSummary()
  - Note: verifier package has no test files yet (logic is exercised indirectly via mobile and document tests)
