### PR TITLE
feat: add gmrtd-verify offline document verifier CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,38 @@ go run ./cmd/gmrtd-reader --can <CAN>
 > - `--doc/--dob/--exp` and `--can` are mutually exclusive.
 > - Requires a PC/SC-compatible NFC reader and a working PC/SC stack.
 
+# ✅ Offline Document Verifier (gmrtd-verify)
+Verifies a serialised CBOR document offline — no NFC hardware required. The CBOR blob is the output of `DocumentEx.ToCbor()`, typically produced by `gmrtd-reader` or the mobile SDK; the verifier replays chip authentication evidence and performs passive authentication, then opens the same HTML report as `gmrtd-reader`.
+
+### Build / run
+```bash
+go run ./cmd/gmrtd-verify -help
+```
+
+### Basic usage
+```bash
+go run ./cmd/gmrtd-verify -file document.gmrtd
+```
+
+### Read from stdin
+```bash
+cat document.gmrtd | go run ./cmd/gmrtd-verify -file -
+```
+
+### With AA challenge binding
+```bash
+go run ./cmd/gmrtd-verify -file document.gmrtd -challenge 0102030405060708
+```
+
+### Flags
+| Flag | Description |
+|---|---|
+| `-file <path>` | Path to CBOR document file; use `-` for stdin |
+| `-challenge <hex>` | 8-byte AA nonce challenge (16 hex chars); binds against AA evidence to close the relay-attack window |
+| `-debug` | Enable debug logging |
+
+> Uses the same built-in CSCA trust stores as `gmrtd-reader`. See [CSCA Trust Stores](#-csca-trust-stores) for coverage.
+
 # 🔍 CSCA Inspection Tool
 A command-line utility for auditing the built-in CSCA trust stores is included at `cmd/gmrtd-csca`.
 

--- a/cmd/gmrtd-verify/main.go
+++ b/cmd/gmrtd-verify/main.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"log/slog"
+	"os"
+
+	"github.com/gmrtd/gmrtd/cms"
+	"github.com/gmrtd/gmrtd/document"
+	"github.com/gmrtd/gmrtd/htmlreport"
+	"github.com/gmrtd/gmrtd/internal/version"
+	"github.com/gmrtd/gmrtd/verifier"
+	"github.com/pkg/browser"
+)
+
+func cmdParams(args []string) (filePath string, debug bool, challenge []byte, err error) {
+	fs := flag.NewFlagSet("gmrtd-verify", flag.ContinueOnError)
+
+	fileFlag := fs.String("file", "", "Path to CBOR document file (use - for stdin)")
+	debugFlag := fs.Bool("debug", false, "Debug")
+	challengeFlag := fs.String("challenge", "", "8-byte AA nonce challenge (hex, e.g. 0102030405060708)")
+
+	if parseErr := fs.Parse(args); parseErr != nil {
+		return "", false, nil, parseErr
+	}
+
+	if *fileFlag == "" {
+		fs.PrintDefaults()
+		return "", false, nil, fmt.Errorf("usage: -file is required")
+	}
+
+	var challengeBytes []byte
+	if *challengeFlag != "" {
+		challengeBytes, err = hex.DecodeString(*challengeFlag)
+		if err != nil {
+			return "", false, nil, fmt.Errorf("invalid -challenge: %w", err)
+		}
+		if len(challengeBytes) != 8 {
+			return "", false, nil, fmt.Errorf("-challenge must be exactly 8 bytes (16 hex chars), got %d hex chars (%d bytes)", len(*challengeFlag), len(challengeBytes))
+		}
+	}
+
+	return *fileFlag, *debugFlag, challengeBytes, nil
+}
+
+func initLogging(debug bool) {
+	logLevel := &slog.LevelVar{}
+	opts := &slog.HandlerOptions{
+		Level: logLevel,
+	}
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, opts))
+	slog.SetDefault(logger)
+	if debug {
+		logLevel.Set(slog.LevelDebug.Level())
+	}
+}
+
+func cscaMasterList() (cms.CertPool, error) {
+	pool, err := cms.DefaultMasterList()
+	if err != nil {
+		return nil, fmt.Errorf("[cscaMasterList] cms.DefaultMasterList error: %w", err)
+	}
+	return pool, nil
+}
+
+func readCborFile(path string) ([]byte, error) {
+	if path == "-" {
+		return io.ReadAll(os.Stdin)
+	}
+	return os.ReadFile(path)
+}
+
+func verifyDocument(cscaCertPool cms.CertPool, challenge []byte, data []byte) (*document.DocumentEx, error) {
+	v := verifier.NewVerifier(cscaCertPool)
+	if challenge != nil {
+		var err error
+		v, err = v.WithAAChallenge(challenge)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return v.Verify(data)
+}
+
+type appDeps struct {
+	cscaMasterList   func() (cms.CertPool, error)
+	readFile         func(path string) ([]byte, error)
+	verify           func(cscaCertPool cms.CertPool, challenge []byte, data []byte) (*document.DocumentEx, error)
+	generateDocument func(*document.DocumentEx) (*bytes.Buffer, error)
+	openBrowser      func(io.Reader) error
+}
+
+func defaultAppDeps() appDeps {
+	return appDeps{
+		cscaMasterList:   cscaMasterList,
+		readFile:         readCborFile,
+		verify:           verifyDocument,
+		generateDocument: htmlreport.Generate,
+		openBrowser:      browser.OpenReader,
+	}
+}
+
+func run(args []string) error {
+	return runWithDeps(args, defaultAppDeps())
+}
+
+func runWithDeps(args []string, deps appDeps) error {
+	fmt.Printf("GMRTD:v%s\n\n", version.Version)
+
+	filePath, debug, challenge, err := cmdParams(args)
+	if err != nil {
+		return err
+	}
+
+	initLogging(debug)
+
+	cscaCertPool, err := deps.cscaMasterList()
+	if err != nil {
+		slog.Error("cscaMasterList error", "error", err)
+		return err
+	}
+
+	cborData, err := deps.readFile(filePath)
+	if err != nil {
+		slog.Error("readFile error", "error", err)
+		return err
+	}
+
+	documentEx, err := deps.verify(cscaCertPool, challenge, cborData)
+	if err != nil {
+		slog.Error("verify error", "error", err)
+		return err
+	}
+
+	docByteBuf, err := deps.generateDocument(documentEx)
+	if err != nil {
+		slog.Error("generateDocument error", "error", err)
+		return err
+	}
+
+	err = deps.openBrowser(docByteBuf)
+	if err != nil {
+		slog.Error("browser.OpenReader error", "error", err)
+		return err
+	}
+
+	return nil
+}
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(0)
+		}
+		log.Printf("%s", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/gmrtd-verify/main_test.go
+++ b/cmd/gmrtd-verify/main_test.go
@@ -1,0 +1,270 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/gmrtd/gmrtd/cms"
+	"github.com/gmrtd/gmrtd/document"
+)
+
+func TestCmdParamsSuccess(t *testing.T) {
+	tests := []struct {
+		name              string
+		args              []string
+		wantFile          string
+		wantDebug         bool
+		wantChallengeHex  string
+	}{
+		{
+			name:      "file only",
+			args:      []string{"-file", "document.gmrtd"},
+			wantFile:  "document.gmrtd",
+			wantDebug: false,
+		},
+		{
+			name:      "file with debug",
+			args:      []string{"-file", "document.gmrtd", "-debug"},
+			wantFile:  "document.gmrtd",
+			wantDebug: true,
+		},
+		{
+			name:             "file with challenge",
+			args:             []string{"-file", "document.gmrtd", "-challenge", "0102030405060708"},
+			wantFile:         "document.gmrtd",
+			wantDebug:        false,
+			wantChallengeHex: "0102030405060708",
+		},
+		{
+			name:             "file debug and challenge",
+			args:             []string{"-file", "document.gmrtd", "-debug", "-challenge", "aabbccddeeff0011"},
+			wantFile:         "document.gmrtd",
+			wantDebug:        true,
+			wantChallengeHex: "aabbccddeeff0011",
+		},
+		{
+			name:      "stdin",
+			args:      []string{"-file", "-"},
+			wantFile:  "-",
+			wantDebug: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			filePath, debug, challenge, err := cmdParams(tc.args)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if filePath != tc.wantFile {
+				t.Fatalf("filePath = %q, want %q", filePath, tc.wantFile)
+			}
+			if debug != tc.wantDebug {
+				t.Fatalf("debug = %v, want %v", debug, tc.wantDebug)
+			}
+			if tc.wantChallengeHex == "" {
+				if challenge != nil {
+					t.Fatalf("challenge = %x, want nil", challenge)
+				}
+			} else {
+				wantHex := strings.ToLower(tc.wantChallengeHex)
+				gotHex := strings.ToLower(fmt.Sprintf("%x", challenge))
+				if gotHex != wantHex {
+					t.Fatalf("challenge = %s, want %s", gotHex, wantHex)
+				}
+			}
+		})
+	}
+}
+
+func TestCmdParamsError(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		errContains string
+	}{
+		{
+			name:        "missing file flag",
+			args:        []string{},
+			errContains: "-file is required",
+		},
+		{
+			name:        "unknown flag",
+			args:        []string{"-unknown"},
+			errContains: "flag provided but not defined",
+		},
+		{
+			name:        "challenge not valid hex",
+			args:        []string{"-file", "document.gmrtd", "-challenge", "zzzzzzzzzzzzzzzz"},
+			errContains: "invalid -challenge",
+		},
+		{
+			name:        "challenge too short",
+			args:        []string{"-file", "document.gmrtd", "-challenge", "010203"},
+			errContains: "must be exactly 8 bytes",
+		},
+		{
+			name:        "challenge too long",
+			args:        []string{"-file", "document.gmrtd", "-challenge", "010203040506070809"},
+			errContains: "must be exactly 8 bytes",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			filePath, debug, challenge, err := cmdParams(tc.args)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.errContains) {
+				t.Fatalf("expected error containing %q, got %q", tc.errContains, err.Error())
+			}
+			if filePath != "" {
+				t.Fatalf("filePath = %q, want empty on error", filePath)
+			}
+			if debug != false {
+				t.Fatalf("debug = %v, want false on error", debug)
+			}
+			if challenge != nil {
+				t.Fatalf("challenge = %x, want nil on error", challenge)
+			}
+		})
+	}
+}
+
+func TestCscaMasterList(t *testing.T) {
+	certPool, err := cscaMasterList()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if certPool == nil {
+		t.Fatalf("certPool expected")
+	}
+
+	const expCertCnt = 500
+	if len(certPool.All()) < expCertCnt {
+		t.Errorf("expected at least %d certs, got %d", expCertCnt, len(certPool.All()))
+	}
+}
+
+func makeDeps(overrides func(*appDeps)) appDeps {
+	deps := appDeps{
+		cscaMasterList: func() (cms.CertPool, error) { return &cms.GenericCertPool{}, nil },
+		readFile:       func(string) ([]byte, error) { return []byte("fake"), nil },
+		verify: func(cms.CertPool, []byte, []byte) (*document.DocumentEx, error) {
+			return &document.DocumentEx{}, nil
+		},
+		generateDocument: func(*document.DocumentEx) (*bytes.Buffer, error) {
+			return bytes.NewBufferString("html"), nil
+		},
+		openBrowser: func(io.Reader) error { return nil },
+	}
+	if overrides != nil {
+		overrides(&deps)
+	}
+	return deps
+}
+
+func TestRunWithDepsSuccess(t *testing.T) {
+	err := runWithDeps([]string{"-file", "document.gmrtd"}, makeDeps(nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunWithDepsSuccessWithChallenge(t *testing.T) {
+	var gotChallenge []byte
+	deps := makeDeps(func(d *appDeps) {
+		d.verify = func(_ cms.CertPool, challenge []byte, _ []byte) (*document.DocumentEx, error) {
+			gotChallenge = challenge
+			return &document.DocumentEx{}, nil
+		}
+	})
+
+	err := runWithDeps([]string{"-file", "document.gmrtd", "-challenge", "0102030405060708"}, deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantChallenge := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	if !bytes.Equal(gotChallenge, wantChallenge) {
+		t.Fatalf("challenge = %x, want %x", gotChallenge, wantChallenge)
+	}
+}
+
+func TestRunWithDepsCmdParamsError(t *testing.T) {
+	err := runWithDeps([]string{}, makeDeps(nil))
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "-file is required") {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+func TestRunWithDepsCscaMasterListError(t *testing.T) {
+	wantErr := errors.New("csca boom")
+
+	err := runWithDeps([]string{"-file", "document.gmrtd"}, makeDeps(func(d *appDeps) {
+		d.cscaMasterList = func() (cms.CertPool, error) { return nil, wantErr }
+	}))
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("got %v, want %v", err, wantErr)
+	}
+}
+
+func TestRunWithDepsReadFileError(t *testing.T) {
+	wantErr := errors.New("read file boom")
+
+	err := runWithDeps([]string{"-file", "document.gmrtd"}, makeDeps(func(d *appDeps) {
+		d.readFile = func(string) ([]byte, error) { return nil, wantErr }
+	}))
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("got %v, want %v", err, wantErr)
+	}
+}
+
+func TestRunWithDepsVerifyError(t *testing.T) {
+	wantErr := errors.New("verify boom")
+
+	err := runWithDeps([]string{"-file", "document.gmrtd"}, makeDeps(func(d *appDeps) {
+		d.verify = func(cms.CertPool, []byte, []byte) (*document.DocumentEx, error) {
+			return nil, wantErr
+		}
+	}))
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("got %v, want %v", err, wantErr)
+	}
+}
+
+func TestRunWithDepsGenerateDocumentError(t *testing.T) {
+	wantErr := errors.New("generate boom")
+
+	err := runWithDeps([]string{"-file", "document.gmrtd"}, makeDeps(func(d *appDeps) {
+		d.generateDocument = func(*document.DocumentEx) (*bytes.Buffer, error) {
+			return nil, wantErr
+		}
+	}))
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("got %v, want %v", err, wantErr)
+	}
+}
+
+func TestRunWithDepsOpenBrowserError(t *testing.T) {
+	wantErr := errors.New("browser boom")
+
+	err := runWithDeps([]string{"-file", "document.gmrtd"}, makeDeps(func(d *appDeps) {
+		d.openBrowser = func(io.Reader) error { return wantErr }
+	}))
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("got %v, want %v", err, wantErr)
+	}
+}

--- a/htmlreport/templates/output.gohtml
+++ b/htmlreport/templates/output.gohtml
@@ -892,7 +892,7 @@ document.addEventListener('DOMContentLoaded', () => {
       <button class="btn" type="button" id="cbor-toggle">Expand</button>
       <button class="btn" type="button" id="cbor-copy-hex">Copy hex</button>
       <button class="btn" type="button" id="cbor-copy-b64">Copy base64</button>
-      <button class="btn" type="button" id="cbor-download">Download .cbor</button>
+      <button class="btn" type="button" id="cbor-download">Download .gmrtd</button>
     </div>
     <span class="copy-status" id="cbor-status"></span>
   </div>
@@ -947,7 +947,7 @@ document.addEventListener('DOMContentLoaded', () => {
     var blob = new Blob([bytes], { type: 'application/cbor' });
     var a = document.createElement('a');
     a.href = URL.createObjectURL(blob);
-    a.download = 'gmrtd-verifiable-doc.cbor';
+    a.download = 'document.gmrtd';
     a.click();
     URL.revokeObjectURL(a.href);
     setStatus('Downloaded');


### PR DESCRIPTION
## Summary

- Add `cmd/gmrtd-verify` — a new CLI that verifies a serialised CBOR document (`.gmrtd`) offline, without NFC hardware, and opens an HTML report in the browser.
- Rename the HTML report download artefact from `gmrtd-verifiable-doc.cbor` → `document.gmrtd` so the downloaded file can be passed directly to `gmrtd-verify -file`.
- Document the new tool in README under **Offline Document Verifier**.

## Changes

### `cmd/gmrtd-verify/main.go`

New CLI entry point.  Pipeline:
1. `cmdParams` — parses `-file`, `-debug`, `-challenge`; validates the challenge is exactly 8 bytes.
2. `cscaMasterList` — loads the built-in CSCA trust store via `cms.DefaultMasterList`.
3. `readCborFile` — reads the file path or stdin.
4. `verifyDocument` — wraps `verifier.NewVerifier` (with optional `WithAAChallenge`).
5. `htmlreport.Generate` → `browser.OpenReader`.

All five steps are wired through an `appDeps` struct so every path is testable without disk or network I/O.

### `cmd/gmrtd-verify/main_test.go`

Table-driven tests for `cmdParams` (success + all error cases) plus `runWithDeps` tests for every dependency failure and both the plain and challenge-bound happy paths.

### `htmlreport/templates/output.gohtml`

Button label: `Download .cbor` → `Download .gmrtd`
Default filename: `gmrtd-verifiable-doc.cbor` → `document.gmrtd`

### `README.md`

New **Offline Document Verifier (gmrtd-verify)** section with build/run instructions, stdin usage, AA challenge binding example, and a flags table.