### PR TITLE
feat(mrz): add OCR-tolerant ConvertMrzToMrzi; optimise NewPasswordMrz

### DIFF
--- a/mrz/mrz.go
+++ b/mrz/mrz.go
@@ -355,6 +355,73 @@ func decodeTD3(mrz string) (*MRZ, error) {
 	return out, nil
 }
 
+func buildMrzi(docNum, docNumCD, dob, dobCD, expiry, expiryCD string) (string, error) {
+	if err := verifyCheckdigit(docNum, docNumCD); err != nil {
+		return "", err
+	}
+	if err := verifyCheckdigit(dob, dobCD); err != nil {
+		return "", err
+	}
+	if err := verifyCheckdigit(expiry, expiryCD); err != nil {
+		return "", err
+	}
+	return docNum + docNumCD + dob + dobCD + expiry + expiryCD, nil
+}
+
+func extractMrziTD1(mrz string) (string, error) {
+	docNum := mrz[5:14]
+	docNumCD := mrz[14:15]
+	optionalData := mrz[15:30]
+
+	if docNumCD == "<" {
+		tmpIdx := strings.Index(optionalData, "<")
+		if tmpIdx < 2 {
+			return "", fmt.Errorf("(extractMrziTD1) invalid encoding. Index must be >=2 (Act:%d)", tmpIdx)
+		}
+		docNum += optionalData[0 : tmpIdx-1]
+		docNumCD = optionalData[tmpIdx-1 : tmpIdx]
+	}
+
+	return buildMrzi(docNum, docNumCD, mrz[30:36], mrz[36:37], mrz[38:44], mrz[44:45])
+}
+
+func extractMrziTD2(mrz string) (string, error) {
+	docNum := mrz[36:45]
+	docNumCD := mrz[45:46]
+	optionalData := mrz[64:71]
+
+	if docNumCD == "<" {
+		tmpIdx := strings.Index(optionalData, "<")
+		if tmpIdx < 2 {
+			return "", fmt.Errorf("(extractMrziTD2) invalid encoding. Index must be >=2 (Act:%d)", tmpIdx)
+		}
+		docNum += optionalData[0 : tmpIdx-1]
+		docNumCD = optionalData[tmpIdx-1 : tmpIdx]
+	}
+
+	return buildMrzi(docNum, docNumCD, mrz[49:55], mrz[55:56], mrz[57:63], mrz[63:64])
+}
+
+func extractMrziTD3(mrz string) (string, error) {
+	return buildMrzi(mrz[44:53], mrz[53:54], mrz[57:63], mrz[63:64], mrz[65:71], mrz[71:72])
+}
+
+// ConvertMrzToMrzi extracts and returns the MRZi from a full MRZ string, validating only
+// the three field-level check digits required to construct the MRZi (document number, date
+// of birth, date of expiry). The composite check digit and all other fields are ignored,
+// so OCR noise outside those three fields does not cause failure.
+func ConvertMrzToMrzi(mrzStr string) (string, error) {
+	switch len(mrzStr) {
+	case MRZLengthTD1:
+		return extractMrziTD1(mrzStr)
+	case MRZLengthTD2:
+		return extractMrziTD2(mrzStr)
+	case MRZLengthTD3:
+		return extractMrziTD3(mrzStr)
+	}
+	return "", fmt.Errorf("unsupported MRZ length (length:%d)", len(mrzStr))
+}
+
 func (mrz *MRZ) EncodeMrzi() (string, error) {
 	// [9] document-number
 	documentNumber := encodeValue(mrz.DocumentNumber, 9, -1)

--- a/mrz/mrz_test.go
+++ b/mrz/mrz_test.go
@@ -433,6 +433,161 @@ func TestDecodeTD3Errors(t *testing.T) {
 	}
 }
 
+func TestConvertMrzToMrzi(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		inp_mrz string
+		exp     string
+	}{
+		{
+			desc:    "TD1 standard",
+			inp_mrz: "I<UTOD231458907<<<<<<<<<<<<<<<7408122F1204159UTO<<<<<<<<<<<6ERIKSSON<<ANNA<MARIA<<<<<<<<<<",
+			exp:     "D23145890774081221204159",
+		},
+		{
+			desc:    "TD1 extended document-number",
+			inp_mrz: "I<UTOD23145890<7349<<<<<<<<<<<3407127M9507122UTO<<<<<<<<<<<2STEVENSON<<PETER<JOHN<<<<<<<<<",
+			exp:     "D23145890734934071279507122",
+		},
+		{
+			desc:    "TD2 standard",
+			inp_mrz: "I<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<D231458907UTO7408122F1204159<<<<<<<6",
+			exp:     "D23145890774081221204159",
+		},
+		{
+			desc:    "TD2 extended document-number",
+			inp_mrz: "I<UTOSTEVENSON<<PETER<JOHN<<<<<<<<<<D23145890<UTO3407127M95071227349<<<8",
+			exp:     "D23145890734934071279507122",
+		},
+		{
+			desc:    "TD3",
+			inp_mrz: "P<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<L898902C36UTO7408122F1204159ZE184226B<<<<<10",
+			exp:     "L898902C3674081221204159",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			act, err := ConvertMrzToMrzi(tc.inp_mrz)
+			if err != nil {
+				t.Errorf("unexpected error: %s", err)
+			}
+			if act != tc.exp {
+				t.Errorf("MRZi mismatch (Exp:%s, Act:%s)", tc.exp, act)
+			}
+		})
+	}
+}
+
+// TestConvertMrzToMrziOcrTolerance verifies that ConvertMrzToMrzi succeeds on MRZ strings
+// that MrzDecode would reject due to errors outside the three required fields.
+func TestConvertMrzToMrziOcrTolerance(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		inp_mrz string
+		exp     string
+	}{
+		{
+			// composite check-digit corrupted (6->7) — MrzDecode rejects this
+			desc:    "TD1 bad composite CD",
+			inp_mrz: "I<UTOD231458907<<<<<<<<<<<<<<<7408122F1204159UTO<<<<<<<<<<<7ERIKSSON<<ANNA<MARIA<<<<<<<<<<",
+			exp:     "D23145890774081221204159",
+		},
+		{
+			// composite check-digit corrupted (6->8) — MrzDecode rejects this
+			desc:    "TD2 bad composite CD",
+			inp_mrz: "I<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<D231458907UTO7408122F1204159<<<<<<<8",
+			exp:     "D23145890774081221204159",
+		},
+		{
+			// optional-data check-digit corrupted (1->2) — MrzDecode rejects this
+			desc:    "TD3 bad optional-data CD",
+			inp_mrz: "P<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<L898902C36UTO7408122F1204159ZE184226B<<<<<20",
+			exp:     "L898902C3674081221204159",
+		},
+		{
+			// composite check-digit corrupted (0->2) — MrzDecode rejects this
+			desc:    "TD3 bad composite CD",
+			inp_mrz: "P<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<L898902C36UTO7408122F1204159ZE184226B<<<<<12",
+			exp:     "L898902C3674081221204159",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			act, err := ConvertMrzToMrzi(tc.inp_mrz)
+			if err != nil {
+				t.Errorf("unexpected error: %s", err)
+			}
+			if act != tc.exp {
+				t.Errorf("MRZi mismatch (Exp:%s, Act:%s)", tc.exp, act)
+			}
+		})
+	}
+}
+
+func TestConvertMrzToMrziErrors(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		inp_mrz string
+	}{
+		{
+			desc:    "bad MRZ length",
+			inp_mrz: "BadMrz",
+		},
+		{
+			desc:    "TD1 bad document-number CD",
+			inp_mrz: "I<UTOD231458905<<<<<<<<<<<<<<<7408122F1204159UTO<<<<<<<<<<<6ERIKSSON<<ANNA<MARIA<<<<<<<<<<",
+		},
+		{
+			desc:    "TD1 bad date-of-birth CD",
+			inp_mrz: "I<UTOD231458907<<<<<<<<<<<<<<<7408124F1204159UTO<<<<<<<<<<<6ERIKSSON<<ANNA<MARIA<<<<<<<<<<",
+		},
+		{
+			desc:    "TD1 bad date-of-expiry CD",
+			inp_mrz: "I<UTOD231458907<<<<<<<<<<<<<<<7408122F1204151UTO<<<<<<<<<<<6ERIKSSON<<ANNA<MARIA<<<<<<<<<<",
+		},
+		{
+			desc:    "TD1 invalid extended document-number encoding",
+			inp_mrz: "I<UTOD23145890<7<<<<<<<<<<<<<<3407127M9507122UTO<<<<<<<<<<<2STEVENSON<<PETER<JOHN<<<<<<<<<",
+		},
+		{
+			desc:    "TD2 bad document-number CD",
+			inp_mrz: "I<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<D231458906UTO7408122F1204159<<<<<<<6",
+		},
+		{
+			desc:    "TD2 bad date-of-birth CD",
+			inp_mrz: "I<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<D231458907UTO7408123F1204159<<<<<<<6",
+		},
+		{
+			desc:    "TD2 bad date-of-expiry CD",
+			inp_mrz: "I<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<D231458907UTO7408122F1204158<<<<<<<6",
+		},
+		{
+			desc:    "TD2 invalid extended document-number encoding",
+			inp_mrz: "I<UTOSTEVENSON<<PETER<JOHN<<<<<<<<<<D23145890<UTO3407127M95071227<<<<<<8",
+		},
+		{
+			desc:    "TD3 bad document-number CD",
+			inp_mrz: "P<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<L898902C34UTO7408122F1204159ZE184226B<<<<<10",
+		},
+		{
+			desc:    "TD3 bad date-of-birth CD",
+			inp_mrz: "P<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<L898902C36UTO7408126F1204159ZE184226B<<<<<10",
+		},
+		{
+			desc:    "TD3 bad date-of-expiry CD",
+			inp_mrz: "P<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<L898902C36UTO7408122F1204151ZE184226B<<<<<10",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			_, err := ConvertMrzToMrzi(tc.inp_mrz)
+			if err == nil {
+				t.Errorf("error expected")
+			}
+		})
+	}
+}
+
 func TestEncodeMrziErrors(t *testing.T) {
 	testCases := []struct {
 		mrz MRZ

--- a/password/password.go
+++ b/password/password.go
@@ -36,22 +36,21 @@ func NewPasswordNil() *Password {
 	return &out
 }
 
+// NewPasswordMrz derives an MRZi password from a raw MRZ string.
+// ConvertMrzToMrzi is used instead of MrzDecode+EncodeMrzi so that only the three
+// fields required to construct the MRZi (document number, date of birth, date of
+// expiry) are validated. The composite check digit and all other MRZ fields are
+// ignored, making this tolerant of OCR noise outside those three fields.
 func NewPasswordMrz(mrzStr string) (pass *Password, err error) {
 	pass = new(Password)
 	pass.PasswordType = PASSWORD_TYPE_MRZi
 
-	var m *mrz.MRZ
-	m, err = mrz.MrzDecode(mrzStr)
+	pass.Password, err = mrz.ConvertMrzToMrzi(mrzStr)
 	if err != nil {
 		return nil, err
 	}
 
-	pass.Password, err = m.EncodeMrzi()
-	if err != nil {
-		return nil, err
-	}
-
-	return pass, err
+	return pass, nil
 }
 
 func NewPasswordMrzi(documentNo, dateOfBirth, dateOfExpiry string) (pass *Password, err error) {

--- a/password/password_test.go
+++ b/password/password_test.go
@@ -26,6 +26,21 @@ func TestNewPasswordMrzTD2(t *testing.T) {
 	}
 }
 
+// TestNewPasswordMrzOcrTolerance verifies that NewPasswordMrz succeeds when the MRZ
+// contains OCR noise outside the three MRZi fields (here: a corrupted composite
+// check digit that MrzDecode would reject).
+func TestNewPasswordMrzOcrTolerance(t *testing.T) {
+	// TD3 with composite check-digit corrupted (0->2); field check digits are valid
+	pass, err := NewPasswordMrz("P<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<L898902C36UTO7408122F1204159ZE184226B<<<<<12")
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+
+	if (pass.PasswordType != PASSWORD_TYPE_MRZi) || (pass.Password != "L898902C3674081221204159") {
+		t.Errorf("Password (MRZ) not encoded correctly")
+	}
+}
+
 func TestNewPasswordMrzInvalid(t *testing.T) {
 	password, err := NewPasswordMrz("InvalidMrzStr")
 	if err == nil {


### PR DESCRIPTION
## Summary
  
- Adds `mrz.ConvertMrzToMrzi(mrzStr string) (string, error)` — a focused MRZ-to-MRZi conversion that validates only the three field-level check digits required to construct the MRZi (document number, date of birth, date of expiry). All other fields and the composite check digit are ignored.
- Updates `password.NewPasswordMrz` to call `ConvertMrzToMrzi` instead of the previous `MrzDecode` + `EncodeMrzi` two-step, making it tolerant of OCR noise outside the three required fields.
  
## Motivation
  
`MrzDecode` validates the composite check digit, which covers several fields beyond the three needed for MRZi. When reading an MRZ via OCR, noise in the name, nationality, or optional-data fields corrupts the composite check digit, causing `MrzDecode` to fail even when the document number, date of birth, and expiry are legible. `ConvertMrzToMrzi` narrows validation to exactly what is needed, so those OCR errors no longer block authentication.
  
## Changes
  
### `mrz/mrz.go`
  
- `buildMrzi` (private) — verifies the three check digit pairs and concatenates the MRZi string.
- `extractMrziTD1` / `extractMrziTD2` / `extractMrziTD3` (private) — extract the relevant raw fields by position for each document format. TD1 and TD2 handle extended document numbers (where `documentNumberCD == "<"` and the number overflows into optional data).
- `ConvertMrzToMrzi` (public) — dispatches by MRZ length, mirrors the structure of `MrzDecode`.
  
### `password/password.go`
  
- `NewPasswordMrz` — replaced `MrzDecode` + `EncodeMrzi` with `mrz.ConvertMrzToMrzi`. Added a doc comment explaining the OCR-tolerance rationale.
  
## Tests
  
### `mrz/mrz_test.go`
  
| Test | Purpose |
|------|---------|
| `TestConvertMrzToMrzi` | Happy path: TD1 standard, TD1 extended doc-num, TD2 standard, TD2 extended doc-num, TD3 |
| `TestConvertMrzToMrziOcrTolerance` | TD1/TD2 bad composite CD, TD3 bad optional-data CD, TD3 bad composite CD — all succeed |
| `TestConvertMrzToMrziErrors` | Bad MRZ length; bad individual field CD for each of the three fields across all three document types; invalid extended doc-num encoding for TD1 and TD2 |
  
### `password/password_test.go`
  
| Test | Purpose |
|------|---------|
| `TestNewPasswordMrzOcrTolerance` | TD3 MRZ with corrupted composite check digit produces correct MRZi |
  
## Test plan
  
- [x] `go test ./mrz/...` — all existing tests pass; 21 new sub-tests pass
- [x] `go test ./password/...` — all existing tests pass; new OCR-tolerance test passes
- [x] `go test ./...` — full suite green