### PR TITLE
feat: decouple ApduLog from DocumentEx, pass it as a separate value

### DIFF
--- a/cmd/gmrtd-reader/main.go
+++ b/cmd/gmrtd-reader/main.go
@@ -155,9 +155,9 @@ func (p *pcscCardProvider) ConnectCard() (smartCard, error) {
 type appDeps struct {
 	cardProvider         func() (cardProvider, error)
 	cscaMasterList       func() (cms.CertPool, error)
-	generateDocument     func(*document.DocumentEx) (*bytes.Buffer, error)
+	generateDocument     func(*document.DocumentEx, *iso7816.ApduLog) (*bytes.Buffer, error)
 	openBrowser          func(io.Reader) error
-	readDocumentFromCard func(pass *password.Password, maxRead uint, skipPace bool, skipImages bool, card smartCard, cscaCertPool cms.CertPool) (*document.DocumentEx, error)
+	readDocumentFromCard func(pass *password.Password, maxRead uint, skipPace bool, skipImages bool, card smartCard, cscaCertPool cms.CertPool) (*document.DocumentEx, *iso7816.ApduLog, error)
 }
 
 func defaultAppDeps() appDeps {
@@ -208,14 +208,14 @@ func runWithDeps(args []string, deps appDeps) error {
 		return err
 	}
 
-	documentEx, err := deps.readDocumentFromCard(pass, maxRead, skipPace, skipImages, card, cscaCertPool)
+	documentEx, apduLog, err := deps.readDocumentFromCard(pass, maxRead, skipPace, skipImages, card, cscaCertPool)
 	if err != nil {
 		slog.Error("readDocumentFromCard", "error", err)
 		return err
 	}
 
 	// generate the HTML document
-	docByteBuf, err := deps.generateDocument(documentEx)
+	docByteBuf, err := deps.generateDocument(documentEx, apduLog)
 	if err != nil {
 		slog.Error("generateDocument", "error", err)
 		return err
@@ -238,7 +238,7 @@ func readDocumentFromCard(
 	skipImages bool,
 	card smartCard,
 	cscaCertPool cms.CertPool,
-) (*document.DocumentEx, error) {
+) (*document.DocumentEx, *iso7816.ApduLog, error) {
 	atr, err := card.ATR()
 	if err != nil {
 		slog.Warn("ATR error", "error", err)

--- a/cmd/gmrtd-reader/main_test.go
+++ b/cmd/gmrtd-reader/main_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gmrtd/gmrtd/cms"
 	"github.com/gmrtd/gmrtd/document"
 	"github.com/gmrtd/gmrtd/htmlreport"
+	"github.com/gmrtd/gmrtd/iso7816"
 	"github.com/gmrtd/gmrtd/password"
 	"github.com/gmrtd/gmrtd/utils"
 )
@@ -41,7 +42,7 @@ func TestGenerateDocument(t *testing.T) {
 
 	// TODO - add in some apdu logs.. should increase test coverage for APDU output
 
-	docByteBuf, err := htmlreport.Generate(&docEx)
+	docByteBuf, err := htmlreport.Generate(&docEx, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -227,7 +228,7 @@ func TestCmdParamsError(t *testing.T) {
 }
 
 func TestGenerateDocumentNilDocument(t *testing.T) {
-	out, err := htmlreport.Generate(nil)
+	out, err := htmlreport.Generate(nil, nil)
 	if err == nil {
 		t.Fatalf("expected error")
 	}
@@ -355,8 +356,8 @@ func TestRunWithDepsReadDocumentFromCardError(t *testing.T) {
 		skipImages bool,
 		card smartCard,
 		cscaCertPool cms.CertPool,
-	) (*document.DocumentEx, error) {
-		return nil, wantErr
+	) (*document.DocumentEx, *iso7816.ApduLog, error) {
+		return nil, nil, wantErr
 	}
 
 	err := runWithDeps([]string{"-can", "123456"}, deps)
@@ -386,10 +387,10 @@ func TestRunWithDepsGenerateDocumentError(t *testing.T) {
 		skipImages bool,
 		card smartCard,
 		cscaCertPool cms.CertPool,
-	) (*document.DocumentEx, error) {
-		return &document.DocumentEx{}, nil
+	) (*document.DocumentEx, *iso7816.ApduLog, error) {
+		return &document.DocumentEx{}, nil, nil
 	}
-	deps.generateDocument = func(*document.DocumentEx) (*bytes.Buffer, error) {
+	deps.generateDocument = func(*document.DocumentEx, *iso7816.ApduLog) (*bytes.Buffer, error) {
 		return nil, wantErr
 	}
 
@@ -420,10 +421,10 @@ func TestRunWithDepsOpenBrowserError(t *testing.T) {
 		skipImages bool,
 		card smartCard,
 		cscaCertPool cms.CertPool,
-	) (*document.DocumentEx, error) {
-		return &document.DocumentEx{}, nil
+	) (*document.DocumentEx, *iso7816.ApduLog, error) {
+		return &document.DocumentEx{}, nil, nil
 	}
-	deps.generateDocument = func(*document.DocumentEx) (*bytes.Buffer, error) {
+	deps.generateDocument = func(*document.DocumentEx, *iso7816.ApduLog) (*bytes.Buffer, error) {
 		return bytes.NewBufferString("html"), nil
 	}
 	deps.openBrowser = func(io.Reader) error {
@@ -442,7 +443,7 @@ func TestRunWithDepsOpenBrowserError(t *testing.T) {
 func TestReadDocumentFromCardReturnsReaderError(t *testing.T) {
 	card := &fakeCard{}
 
-	_, err := readDocumentFromCard(
+	_, _, err := readDocumentFromCard(
 		password.NewPasswordCan("123456"),
 		0,
 		false,
@@ -471,7 +472,7 @@ func (c *fakeCardWithAtrAtsError) ATS() ([]byte, error) {
 func TestReadDocumentFromCardIgnoresAtrAtsErrors(t *testing.T) {
 	card := &fakeCardWithAtrAtsError{}
 
-	_, err := readDocumentFromCard(
+	_, _, err := readDocumentFromCard(
 		password.NewPasswordCan("123456"),
 		0,
 		false,
@@ -501,7 +502,7 @@ func (c *fakeCardApduError) Apdu([]byte) ([]byte, error) {
 func TestReadDocumentFromCardPropagatesReaderFailureFromApdu(t *testing.T) {
 	card := &fakeCardApduError{}
 
-	_, err := readDocumentFromCard(
+	_, _, err := readDocumentFromCard(
 		password.NewPasswordCan("123456"),
 		1000,
 		true,

--- a/cmd/gmrtd-verify/main.go
+++ b/cmd/gmrtd-verify/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gmrtd/gmrtd/document"
 	"github.com/gmrtd/gmrtd/htmlreport"
 	"github.com/gmrtd/gmrtd/internal/version"
+	"github.com/gmrtd/gmrtd/iso7816"
 	"github.com/gmrtd/gmrtd/verifier"
 	"github.com/pkg/browser"
 )
@@ -92,7 +93,7 @@ type appDeps struct {
 	cscaMasterList   func() (cms.CertPool, error)
 	readFile         func(path string) ([]byte, error)
 	verify           func(cscaCertPool cms.CertPool, challenge []byte, data []byte) (*document.DocumentEx, error)
-	generateDocument func(*document.DocumentEx) (*bytes.Buffer, error)
+	generateDocument func(*document.DocumentEx, *iso7816.ApduLog) (*bytes.Buffer, error)
 	openBrowser      func(io.Reader) error
 }
 
@@ -138,7 +139,7 @@ func runWithDeps(args []string, deps appDeps) error {
 		return err
 	}
 
-	docByteBuf, err := deps.generateDocument(documentEx)
+	docByteBuf, err := deps.generateDocument(documentEx, nil)
 	if err != nil {
 		slog.Error("generateDocument error", "error", err)
 		return err

--- a/cmd/gmrtd-verify/main_test.go
+++ b/cmd/gmrtd-verify/main_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gmrtd/gmrtd/cms"
 	"github.com/gmrtd/gmrtd/document"
+	"github.com/gmrtd/gmrtd/iso7816"
 )
 
 func TestCmdParamsSuccess(t *testing.T) {
@@ -159,7 +160,7 @@ func makeDeps(overrides func(*appDeps)) appDeps {
 		verify: func(cms.CertPool, []byte, []byte) (*document.DocumentEx, error) {
 			return &document.DocumentEx{}, nil
 		},
-		generateDocument: func(*document.DocumentEx) (*bytes.Buffer, error) {
+		generateDocument: func(*document.DocumentEx, *iso7816.ApduLog) (*bytes.Buffer, error) {
 			return bytes.NewBufferString("html"), nil
 		},
 		openBrowser: func(io.Reader) error { return nil },
@@ -248,7 +249,7 @@ func TestRunWithDepsGenerateDocumentError(t *testing.T) {
 	wantErr := errors.New("generate boom")
 
 	err := runWithDeps([]string{"-file", "document.gmrtd"}, makeDeps(func(d *appDeps) {
-		d.generateDocument = func(*document.DocumentEx) (*bytes.Buffer, error) {
+		d.generateDocument = func(*document.DocumentEx, *iso7816.ApduLog) (*bytes.Buffer, error) {
 			return nil, wantErr
 		}
 	}))

--- a/document/document_ex.go
+++ b/document/document_ex.go
@@ -1,13 +1,8 @@
 package document
 
-import (
-	"github.com/gmrtd/gmrtd/iso7816"
-)
-
 type DocumentEx struct {
-	Document Document         `json:"document"`
-	Session  Session          `json:"session"`
-	ApduLog  *iso7816.ApduLog `json:"apduLog,omitempty"`
+	Document Document `json:"document"`
+	Session  Session  `json:"session"`
 }
 
 func (docEx *DocumentEx) GenerateSummary() {

--- a/htmlreport/report.go
+++ b/htmlreport/report.go
@@ -23,6 +23,7 @@ var templateFS embed.FS
 
 type templateData struct {
 	*document.DocumentEx
+	ApduLog    *iso7816.ApduLog
 	CborBase64 string
 }
 
@@ -73,8 +74,9 @@ func executeDocumentTemplate(tmpl *template.Template, data *templateData) (*byte
 	return byteBuf, nil
 }
 
-// Generate renders a DocumentEx to an HTML report.
-func Generate(documentEx *document.DocumentEx) (*bytes.Buffer, error) {
+// Generate renders a DocumentEx (plus, if available, the APDU log captured during the
+// read/verify) to an HTML report.
+func Generate(documentEx *document.DocumentEx, apduLog *iso7816.ApduLog) (*bytes.Buffer, error) {
 	if documentEx == nil {
 		return nil, fmt.Errorf("[generateDocument] documentEx cannot be nil")
 	}
@@ -84,7 +86,7 @@ func Generate(documentEx *document.DocumentEx) (*bytes.Buffer, error) {
 		return nil, fmt.Errorf("[generateDocument] ParseFS error: %w", err)
 	}
 
-	data := &templateData{DocumentEx: documentEx}
+	data := &templateData{DocumentEx: documentEx, ApduLog: apduLog}
 
 	cborBytes, err := documentEx.ToCbor()
 	if err != nil {

--- a/htmlreport/report_test.go
+++ b/htmlreport/report_test.go
@@ -28,7 +28,7 @@ func TestExecuteDocumentTemplateError(t *testing.T) {
 }
 
 func TestGenerateNilError(t *testing.T) {
-	buf, err := Generate(nil)
+	buf, err := Generate(nil, nil)
 	if err == nil {
 		t.Fatal("expected error for nil documentEx")
 	}
@@ -38,7 +38,7 @@ func TestGenerateNilError(t *testing.T) {
 }
 
 func TestGenerateEmptyDocumentEx(t *testing.T) {
-	buf, err := Generate(&document.DocumentEx{})
+	buf, err := Generate(&document.DocumentEx{}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -77,7 +77,7 @@ func TestGenerateWithSession(t *testing.T) {
 		},
 	}
 
-	buf, err := Generate(docEx)
+	buf, err := Generate(docEx, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -97,7 +97,7 @@ func TestGenerateWithSessionErrors(t *testing.T) {
 		},
 	}
 
-	buf, err := Generate(docEx)
+	buf, err := Generate(docEx, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -120,7 +120,7 @@ func TestGenerateWithApduLog(t *testing.T) {
 	entryWithChild.Finalise([]byte{0x01, 0x02, 0x90, 0x00})
 	log.Add(entryWithChild)
 
-	buf, err := Generate(&document.DocumentEx{ApduLog: log})
+	buf, err := Generate(&document.DocumentEx{}, log)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -98,6 +98,7 @@ type Reader struct {
 
 type Document struct {
 	documentEx *document.DocumentEx
+	apduLog    *iso7816.ApduLog
 }
 
 func NewReader(status ReaderStatus, transceiver Transceiver) *Reader {
@@ -192,7 +193,7 @@ func (r *Reader) ReadDocument(password *MrtdPassword, atr []byte, ats []byte) (d
 		}
 	}
 
-	doc.documentEx, err = gmrtdReader.ReadDocument(password.password, atr, ats)
+	doc.documentEx, doc.apduLog, err = gmrtdReader.ReadDocument(password.password, atr, ats)
 
 	return doc, err
 }
@@ -280,4 +281,16 @@ func (doc *Document) DocumentExCbor() (cborData []byte, err error) {
 	}
 
 	return doc.documentEx.ToCbor()
+}
+
+// ApduLogJson returns the APDU trace captured during Reader.ReadDocument, as JSON.
+// Not populated by Verifier.Verify, which never talks to a chip - an empty log is
+// returned in that case rather than an error.
+func (doc *Document) ApduLogJson() (jsonData []byte, err error) {
+	apduLog := doc.apduLog
+	if apduLog == nil {
+		apduLog = iso7816.NewApduLog()
+	}
+
+	return json.Marshal(apduLog)
 }

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -139,8 +139,8 @@ func NewReaderState(atr []byte, ats []byte, password *password.Password) *Reader
 
 // reads the document using the specified transceiver and password
 // - also performs doc.Verify() and Passive Authentication!
-// NB returns partial data (docEx) in the event of an error
-func (reader *Reader) ReadDocument(password *password.Password, atr []byte, ats []byte) (docEx *document.DocumentEx, err error) {
+// NB returns partial data (docEx, apduLog) in the event of an error
+func (reader *Reader) ReadDocument(password *password.Password, atr []byte, ats []byte) (docEx *document.DocumentEx, apduLog *iso7816.ApduLog, err error) {
 	defer func() {
 		if e := recover(); e != nil {
 			switch x := e.(type) {
@@ -175,15 +175,13 @@ func (reader *Reader) ReadDocument(password *password.Password, atr []byte, ats 
 		calculateDocumentSummary,
 	)
 	if err != nil {
-		return state.docEx, fmt.Errorf("[ReadDocument] runSteps error: %w", err)
+		return state.docEx, reader.nfc.ApduLog(), fmt.Errorf("[ReadDocument] runSteps error: %w", err)
 	}
-
-	state.docEx.ApduLog = reader.nfc.ApduLog()
 
 	reader.status.Status("Finished!")
 	slog.Info("** ReadDocument FINISHED **", "VerifiedChipAuthStatus", state.docEx.Session.VerifiedChipAuthStatus())
 
-	return state.docEx, nil
+	return state.docEx, reader.nfc.ApduLog(), nil
 }
 
 type ReaderStep func(*Reader, *ReaderState) error

--- a/reader/reader_test.go
+++ b/reader/reader_test.go
@@ -782,7 +782,7 @@ func TestReadDocumentTransceiverPanicIsHandled(t *testing.T) {
 			reader := NewReader(&status, nfc, EmptyCscaTrustStore(t))
 			pass := password.NewPasswordCan("123456")
 
-			_, err := reader.ReadDocument(pass, nil, nil)
+			_, _, err := reader.ReadDocument(pass, nil, nil)
 			if err == nil {
 				t.Fatalf("expected error")
 			}


### PR DESCRIPTION
 ## Summary

`DocumentEx.ApduLog` is removed; the APDU trace captured during a card read is now threaded through as its own return value / parameter instead of being bolted onto the document model.

- `document.DocumentEx` no longer has an `ApduLog` field (and no longer imports `iso7816` at all) — it's back to being a plain `Document` + `Session` struct.
- `reader.Reader.ReadDocument` now returns `(*document.DocumentEx, *iso7816.ApduLog, error)` instead of stuffing the log into `docEx`.
- `htmlreport.Generate` takes the log as an explicit second argument (`Generate(documentEx, apduLog)`), so the HTML report generator no longer depends on the document type carrying reader-session state.
- `cmd/gmrtd-reader` and `cmd/gmrtd-verify` are updated to plumb the log (or `nil`, in the verify case, which never talks to a chip) through to report generation.
- `mobile.Document` gains its own `apduLog` field and a new `ApduLogJson()` accessor, so mobile bindings can fetch the trace independently of the document data. `Verifier.Verify` never produces a log, so `ApduLogJson()` returns an empty log rather than erroring in that case.

## Motivation

`ApduLog` is a diagnostic artefact of a *reader session*, not part of the parsed document data — bundling it into `DocumentEx` meant every consumer of the document model (verify path, CBOR serialisation, mobile bindings) had to account for a field that's only ever populated on one of the two read paths. Splitting it out keeps `DocumentEx` a clean, purely-data type and makes the "verify path has no APDU log" behaviour explicit at each call site rather than implicit via a nil field.