### PR TITLE
feat: add DocumentSummary; compute Summary on demand

### DIFF
--- a/cmd/gmrtd-reader/main.go
+++ b/cmd/gmrtd-reader/main.go
@@ -193,7 +193,6 @@ func sampleDocument(cscaCertPool cms.CertPool) (*document.DocumentEx, error) {
 
 	docEx := &document.DocumentEx{Document: *doc}
 	docEx.Session.PassiveAuthResult, docEx.Session.PassiveAuthErr = passiveauth.PassiveAuth(doc, cscaCertPool)
-	docEx.GenerateSummary()
 
 	return docEx, nil
 }

--- a/document/dg1.go
+++ b/document/dg1.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/gmrtd/gmrtd/iso3166"
 	"github.com/gmrtd/gmrtd/mrz"
 	"github.com/gmrtd/gmrtd/tlv"
 )
@@ -12,9 +11,9 @@ import (
 const DG1Tag = 0x61
 
 type DG1 struct {
-	RawData []byte    `json:"rawData,omitempty"`
-	RawMrz  string    `json:"rawMrz,omitempty"`
-	Mrz     *mrz.MRZ  `json:"mrz,omitempty"`
+	RawData []byte   `json:"rawData,omitempty"`
+	RawMrz  string   `json:"rawMrz,omitempty"`
+	Mrz     *mrz.MRZ `json:"mrz,omitempty"`
 }
 
 func (f *DG1) GetRawData() []byte { return f.RawData }
@@ -62,18 +61,10 @@ func (dg1 DG1) IssuingCountryAlpha2() (string, error) {
 	}
 
 	// NB use Issuing-State to derive the country-code
-	var mrzCountryAlpha3 string = dg1.Mrz.IssuingState
-
-	// Note: special handling for Germany, who use 'special' country-code (D) in the MRZ
-	//       - refer to ICAO9303p3 (5. CODES FOR NATIONALITY...)
-	if mrzCountryAlpha3 == "D" {
-		mrzCountryAlpha3 = "DEU"
+	info, err := ResolveCountry(dg1.Mrz.IssuingState)
+	if err != nil {
+		return "", fmt.Errorf("(IssuingCountryAlpha2) %w", err)
 	}
 
-	country := iso3166.ByAlpha3(mrzCountryAlpha3)
-	if country == nil {
-		return "", fmt.Errorf("(IssuingCountryAlpha2) Unable to resolve alpha3 country code (%s)", mrzCountryAlpha3)
-	}
-
-	return country.Alpha2, nil
+	return info.Alpha2, nil
 }

--- a/document/document_ex.go
+++ b/document/document_ex.go
@@ -5,14 +5,24 @@ type DocumentEx struct {
 	Session  Session  `json:"session"`
 }
 
-func (docEx *DocumentEx) GenerateSummary() {
-	docEx.Session.Summary = &DocumentSummary{
-		DataTrusted: docEx.Session.DocumentVerifyErr == nil &&
-			docEx.Session.PassiveAuthResult != nil &&
-			docEx.Session.PassiveAuthResult.Success,
-		ChipAuthenticity: docEx.Session.VerifiedChipAuthStatus(),
-		LdsVersion:       docEx.Document.LdsVersion(),
-		UnicodeVersion:   docEx.Document.UnicodeVersion(),
+// Summary derives a DocumentSummary from the current Document/Session state. It is
+// computed fresh on every call rather than cached - call it any time after the relevant
+// session steps (Document.Verify, Passive Authentication, chip authentication) have run.
+//
+// IdentityAttributes is always populated from whatever DG data is present, regardless of
+// DataTrusted - callers that need to distinguish an untrustworthy read (unverified SOD,
+// tampered DG, etc.) from a genuinely empty document must check DataTrusted themselves
+// rather than relying on IdentityAttributes's presence.
+func (docEx *DocumentEx) Summary() *DocumentSummary {
+	dataTrusted := docEx.Session.DocumentVerifyErr == nil &&
+		docEx.Session.PassiveAuthResult != nil &&
+		docEx.Session.PassiveAuthResult.Success
+
+	return &DocumentSummary{
+		DataTrusted:        dataTrusted,
+		ChipAuthenticity:   docEx.Session.VerifiedChipAuthStatus(),
+		LdsVersion:         docEx.Document.LdsVersion(),
+		UnicodeVersion:     docEx.Document.UnicodeVersion(),
+		IdentityAttributes: buildIdentityAttributes(&docEx.Document),
 	}
 }
-

--- a/document/document_ex_test.go
+++ b/document/document_ex_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestGenerateSummaryPassiveAuthSuccess(t *testing.T) {
+func TestSummaryPassiveAuthSuccess(t *testing.T) {
 	docEx := &DocumentEx{
 		Session: Session{
 			ChipAuthResult:    &ChipAuthResult{Success: true},
@@ -13,20 +13,20 @@ func TestGenerateSummaryPassiveAuthSuccess(t *testing.T) {
 		},
 	}
 
-	docEx.GenerateSummary()
+	summary := docEx.Summary()
 
-	if docEx.Session.Summary == nil {
+	if summary == nil {
 		t.Fatal("expected Summary to be non-nil")
 	}
-	if !docEx.Session.Summary.DataTrusted {
+	if !summary.DataTrusted {
 		t.Error("expected DataTrusted to be true")
 	}
-	if docEx.Session.Summary.ChipAuthenticity != CHIP_AUTH_STATUS_CA {
-		t.Errorf("expected ChipAuthenticity CA, got %d", docEx.Session.Summary.ChipAuthenticity)
+	if summary.ChipAuthenticity != CHIP_AUTH_STATUS_CA {
+		t.Errorf("expected ChipAuthenticity CA, got %d", summary.ChipAuthenticity)
 	}
 }
 
-func TestGenerateSummaryPassiveAuthFail(t *testing.T) {
+func TestSummaryPassiveAuthFail(t *testing.T) {
 	docEx := &DocumentEx{
 		Session: Session{
 			ChipAuthResult:    &ChipAuthResult{Success: true},
@@ -34,20 +34,20 @@ func TestGenerateSummaryPassiveAuthFail(t *testing.T) {
 		},
 	}
 
-	docEx.GenerateSummary()
+	summary := docEx.Summary()
 
-	if docEx.Session.Summary == nil {
+	if summary == nil {
 		t.Fatal("expected Summary to be non-nil")
 	}
-	if docEx.Session.Summary.DataTrusted {
+	if summary.DataTrusted {
 		t.Error("expected DataTrusted to be false")
 	}
-	if docEx.Session.Summary.ChipAuthenticity != CHIP_AUTH_STATUS_NONE {
-		t.Errorf("expected ChipAuthenticity NONE, got %d", docEx.Session.Summary.ChipAuthenticity)
+	if summary.ChipAuthenticity != CHIP_AUTH_STATUS_NONE {
+		t.Errorf("expected ChipAuthenticity NONE, got %d", summary.ChipAuthenticity)
 	}
 }
 
-func TestGenerateSummaryDocumentVerifyErr(t *testing.T) {
+func TestSummaryDocumentVerifyErr(t *testing.T) {
 	docEx := &DocumentEx{
 		Session: Session{
 			ChipAuthResult:    &ChipAuthResult{Success: true},
@@ -56,48 +56,62 @@ func TestGenerateSummaryDocumentVerifyErr(t *testing.T) {
 		},
 	}
 
-	docEx.GenerateSummary()
+	summary := docEx.Summary()
 
-	if docEx.Session.Summary == nil {
+	if summary == nil {
 		t.Fatal("expected Summary to be non-nil")
 	}
-	if docEx.Session.Summary.DataTrusted {
+	if summary.DataTrusted {
 		t.Error("expected DataTrusted to be false when DocumentVerifyErr is set, even if PassiveAuth succeeded")
 	}
 }
 
-func TestGenerateSummaryNoPassiveAuth(t *testing.T) {
+func TestSummaryNoPassiveAuth(t *testing.T) {
 	docEx := &DocumentEx{
 		Session: Session{
 			ChipAuthResult: &ChipAuthResult{Success: true},
 		},
 	}
 
-	docEx.GenerateSummary()
+	summary := docEx.Summary()
 
-	if docEx.Session.Summary == nil {
+	if summary == nil {
 		t.Fatal("expected Summary to be non-nil")
 	}
-	if docEx.Session.Summary.DataTrusted {
+	if summary.DataTrusted {
 		t.Error("expected DataTrusted to be false when no PassiveAuthResult")
 	}
-	if docEx.Session.Summary.ChipAuthenticity != CHIP_AUTH_STATUS_NONE {
-		t.Errorf("expected ChipAuthenticity NONE, got %d", docEx.Session.Summary.ChipAuthenticity)
+	if summary.ChipAuthenticity != CHIP_AUTH_STATUS_NONE {
+		t.Errorf("expected ChipAuthenticity NONE, got %d", summary.ChipAuthenticity)
 	}
 }
 
-func TestGenerateSummaryEmpty(t *testing.T) {
+func TestSummaryEmpty(t *testing.T) {
 	docEx := &DocumentEx{}
 
-	docEx.GenerateSummary()
+	summary := docEx.Summary()
 
-	if docEx.Session.Summary == nil {
+	if summary == nil {
 		t.Fatal("expected Summary to be non-nil")
 	}
-	if docEx.Session.Summary.DataTrusted {
+	if summary.DataTrusted {
 		t.Error("expected DataTrusted to be false")
 	}
-	if docEx.Session.Summary.ChipAuthenticity != CHIP_AUTH_STATUS_NONE {
-		t.Errorf("expected ChipAuthenticity NONE, got %d", docEx.Session.Summary.ChipAuthenticity)
+	if summary.ChipAuthenticity != CHIP_AUTH_STATUS_NONE {
+		t.Errorf("expected ChipAuthenticity NONE, got %d", summary.ChipAuthenticity)
+	}
+}
+
+func TestSummaryIsComputedFreshNotCached(t *testing.T) {
+	docEx := &DocumentEx{}
+
+	if docEx.Summary().DataTrusted {
+		t.Fatal("expected DataTrusted to be false before PassiveAuthResult is set")
+	}
+
+	docEx.Session.PassiveAuthResult = &PassiveAuthResult{Success: true, Sod: NewPassiveAuth(nil)}
+
+	if !docEx.Summary().DataTrusted {
+		t.Error("expected DataTrusted to be true after PassiveAuthResult is set - Summary must reflect current state, not a stale snapshot")
 	}
 }

--- a/document/document_summary.go
+++ b/document/document_summary.go
@@ -1,0 +1,239 @@
+package document
+
+import (
+	"fmt"
+
+	"github.com/gmrtd/gmrtd/iso3166"
+	"github.com/gmrtd/gmrtd/mrz"
+	"github.com/gmrtd/gmrtd/utils"
+)
+
+// CountryInfo resolves an MRZ alpha-3 country code to its alpha-2 code and full name.
+type CountryInfo struct {
+	Alpha3 string `json:"alpha3,omitempty"`
+	Alpha2 string `json:"alpha2,omitempty"`
+	Name   string `json:"name,omitempty"`
+}
+
+// ResolveCountry resolves an MRZ alpha-3 country code (as found in DG1's IssuingState /
+// Nationality) to a CountryInfo. Handles ICAO 9303 quirks such as Germany's special code
+// "D" (mapped to "DEU").
+func ResolveCountry(mrzAlpha3 string) (*CountryInfo, error) {
+	// special handling for Germany per ICAO9303p3 (5. CODES FOR NATIONALITY...)
+	if mrzAlpha3 == "D" {
+		mrzAlpha3 = "DEU"
+	}
+
+	country := iso3166.ByAlpha3(mrzAlpha3)
+	if country == nil {
+		return nil, fmt.Errorf("[ResolveCountry] unable to resolve alpha-3 country code (%s)", mrzAlpha3)
+	}
+
+	return &CountryInfo{Alpha3: country.Alpha3, Alpha2: country.Alpha2, Name: country.Name}, nil
+}
+
+// resolveCountryTolerant resolves an MRZ alpha-3 country code to a CountryInfo, same as
+// ResolveCountry. Unlike ResolveCountry, it never fails: MRZ country codes are sometimes
+// fictitious (e.g. "UTO" for the fictitious country of Utopia, used by ICAO 9303
+// sample/test documents) and can't be resolved to an alpha-2 code or name, so in that case
+// it returns a CountryInfo with just the raw Alpha3 code set.
+func resolveCountryTolerant(mrzAlpha3 string) *CountryInfo {
+	if info, err := ResolveCountry(mrzAlpha3); err == nil {
+		return info
+	}
+
+	return &CountryInfo{Alpha3: mrzAlpha3}
+}
+
+// ImageData is a raw image (e.g. face photo, signature) together with its detected format.
+type ImageData struct {
+	Data   []byte            `json:"data,omitempty"`
+	Format utils.ImageFormat `json:"format,omitempty"`
+}
+
+func newImageData(raw []byte) ImageData {
+	format, _ := utils.DetectImageFormat(raw)
+	return ImageData{Data: raw, Format: format}
+}
+
+// IdentityAttributes is a flattened, client-friendly view of the data spread across a
+// Document's Data Groups (DG1 MRZ, DG2, DG7, DG11, DG12, DG16). Where multiple DGs carry
+// the same field, the higher-fidelity source wins - see buildIdentityAttributes for the
+// precedence rules. It reflects whatever DG data is present regardless of whether that
+// data has been cryptographically verified - see DocumentSummary.DataTrusted.
+type IdentityAttributes struct {
+	DocumentCode   string       `json:"documentCode,omitempty"`
+	IssuingState   *CountryInfo `json:"issuingState,omitempty"`
+	DocumentNumber string       `json:"documentNumber,omitempty"`
+	Nationality    *CountryInfo `json:"nationality,omitempty"`
+	Sex            string       `json:"sex,omitempty"`
+
+	// Name is resolved from DG11 if present, else DG1 MRZ. NameMrzRaw is always the DG1
+	// MRZ value (regardless of which source Name resolved to) since the MRZ name is
+	// truncated/transliterated and clients may want to see/reconcile it against the
+	// higher-fidelity DG11 name rather than rely on the precedence gmrtd applies.
+	Name       *mrz.MrzName  `json:"name,omitempty"`
+	NameMrzRaw *mrz.MrzName  `json:"nameMrzRaw,omitempty"`
+	OtherNames []mrz.MrzName `json:"otherNames,omitempty"`
+
+	// DateOfBirth is DG11's FullDateOfBirth (YYYYMMDD) if present, else the raw DG1 MRZ
+	// value (YYMMDD, no century - MRZ carries no century for DOB and gmrtd does not guess
+	// one). The raw, per-source values are also surfaced below since DOB may be present in
+	// both DG1 and DG11, and clients may want to see/reconcile both rather than rely on the
+	// precedence gmrtd applies.
+	DateOfBirth        string `json:"dateOfBirth,omitempty"`
+	DateOfBirthMrzRaw  string `json:"dateOfBirthMrzRaw,omitempty"`  // DG1 MRZ, raw YYMMDD (2-digit year)
+	DateOfBirthDg11Raw string `json:"dateOfBirthDg11Raw,omitempty"` // DG11, raw YYYYMMDD
+
+	// DateOfExpiry is the raw DG1 MRZ value (YYMMDD, no century), its only source.
+	DateOfExpiry       string `json:"dateOfExpiry,omitempty"`
+	DateOfExpiryMrzRaw string `json:"dateOfExpiryMrzRaw,omitempty"` // DG1 MRZ, raw YYMMDD (2-digit year)
+
+	PlaceOfBirth []string `json:"placeOfBirth,omitempty"`
+	Address      []string `json:"address,omitempty"`
+	Telephone    string   `json:"telephone,omitempty"`
+	Profession   string   `json:"profession,omitempty"`
+	Title        string   `json:"title,omitempty"`
+
+	PersonalNumber   string `json:"personalNumber,omitempty"`   // DG11 only
+	MrzOptionalData  string `json:"mrzOptionalData,omitempty"`  // raw MRZ, unresolved
+	MrzOptionalData2 string `json:"mrzOptionalData2,omitempty"` // TD1 only
+
+	IssuingAuthority string `json:"issuingAuthority,omitempty"`
+
+	// DateOfIssue is the raw DG12 value (YYYYMMDD), its only source.
+	DateOfIssue    string `json:"dateOfIssue,omitempty"`
+	DateOfIssueRaw string `json:"dateOfIssueRaw,omitempty"` // DG12, raw YYYYMMDD
+
+	FaceImages         []ImageData `json:"faceImages,omitempty"`
+	SignatureImages    []ImageData `json:"signatureImages,omitempty"`
+	DocumentImageFront *ImageData  `json:"documentImageFront,omitempty"`
+	DocumentImageRear  *ImageData  `json:"documentImageRear,omitempty"`
+
+	PersonsToNotify []PersonToNotify `json:"personsToNotify,omitempty"`
+}
+
+// DocumentSummary is a client-friendly view of a document's overall trust/authenticity
+// state, derived from a DocumentEx's Document + Session data. See DocumentEx.Summary,
+// which computes it fresh on each call rather than storing it as session state.
+type DocumentSummary struct {
+	DataTrusted      bool           `json:"dataTrusted"`
+	ChipAuthenticity ChipAuthStatus `json:"chipAuthenticity"`
+	LdsVersion       string         `json:"ldsVersion,omitempty"`
+	UnicodeVersion   string         `json:"unicodeVersion,omitempty"`
+
+	// IdentityAttributes reflects whatever DG data is present, regardless of DataTrusted -
+	// e.g. a failed Passive Authentication still surfaces the (unverified) MRZ/DG11/DG12
+	// data, since callers may want to inspect it for manual review. DataTrusted is the sole
+	// signal for whether this data has been cryptographically verified; callers must check
+	// it before treating IdentityAttributes as authentic.
+	IdentityAttributes *IdentityAttributes `json:"identityAttributes,omitempty"`
+}
+
+// buildIdentityAttributes resolves an IdentityAttributes from doc's Data Groups. Every DG
+// is optional per LDS1, so every access is nil-safe. Field precedence where more than one
+// DG carries the same data:
+//   - Name/DateOfBirth: DG11 wins over DG1 MRZ when present - DG11 has full-fidelity
+//     names (MRZ truncates/transliterates) and an explicit-century date of birth. The DG1
+//     MRZ value is still surfaced separately (NameMrzRaw/DateOfBirthMrzRaw) even when
+//     overridden.
+//   - PersonalNumber: DG11 only. MRZ's optional-data fields are issuer-discretionary and
+//     not reliably a personal number, so they're surfaced separately, unresolved.
+func buildIdentityAttributes(doc *Document) *IdentityAttributes {
+	summary := &IdentityAttributes{}
+
+	dg1 := doc.Mf.Lds1.Dg1
+	dg2 := doc.Mf.Lds1.Dg2
+	dg7 := doc.Mf.Lds1.Dg7
+	dg11 := doc.Mf.Lds1.Dg11
+	dg12 := doc.Mf.Lds1.Dg12
+	dg16 := doc.Mf.Lds1.Dg16
+
+	if dg1 != nil && dg1.Mrz != nil {
+		m := dg1.Mrz
+
+		summary.DocumentCode = m.DocumentCode
+		summary.DocumentNumber = m.DocumentNumber
+		summary.Sex = m.Sex
+		summary.Name = m.NameOfHolder
+		summary.NameMrzRaw = m.NameOfHolder
+		summary.MrzOptionalData = m.OptionalData
+		summary.MrzOptionalData2 = m.OptionalData2
+
+		if len(m.IssuingState) > 0 {
+			summary.IssuingState = resolveCountryTolerant(m.IssuingState)
+		}
+		if len(m.Nationality) > 0 {
+			summary.Nationality = resolveCountryTolerant(m.Nationality)
+		}
+
+		if len(m.DateOfBirth) > 0 {
+			summary.DateOfBirthMrzRaw = m.DateOfBirth
+			// MRZ carries no century for DOB; surface the raw YYMMDD value as-is rather than
+			// guess. DG11's FullDateOfBirth (explicit century), if present, overrides below.
+			summary.DateOfBirth = m.DateOfBirth
+		}
+		if len(m.DateOfExpiry) > 0 {
+			summary.DateOfExpiryMrzRaw = m.DateOfExpiry
+			summary.DateOfExpiry = m.DateOfExpiry
+		}
+	}
+
+	if dg11 != nil {
+		d := dg11.Details
+
+		if d.NameOfHolder != nil {
+			summary.Name = d.NameOfHolder
+		}
+		summary.OtherNames = d.OtherNames
+		summary.PersonalNumber = d.PersonalNumber
+		summary.PlaceOfBirth = d.PlaceOfBirth
+		summary.Address = d.Address
+		summary.Telephone = d.Telephone
+		summary.Profession = d.Profession
+		summary.Title = d.Title
+
+		if len(d.FullDateOfBirth) > 0 {
+			summary.DateOfBirthDg11Raw = d.FullDateOfBirth
+			summary.DateOfBirth = d.FullDateOfBirth
+		}
+	}
+
+	if dg12 != nil {
+		d := dg12.Details
+
+		summary.IssuingAuthority = d.IssuingAuthority
+
+		if len(d.DateOfIssue) > 0 {
+			summary.DateOfIssueRaw = d.DateOfIssue
+			summary.DateOfIssue = d.DateOfIssue
+		}
+
+		if len(d.ImageFront) > 0 {
+			img := newImageData(d.ImageFront)
+			summary.DocumentImageFront = &img
+		}
+		if len(d.ImageRear) > 0 {
+			img := newImageData(d.ImageRear)
+			summary.DocumentImageRear = &img
+		}
+	}
+
+	if dg2 != nil {
+		for _, image := range dg2.Images {
+			summary.FaceImages = append(summary.FaceImages, newImageData(image.Image))
+		}
+	}
+
+	if dg7 != nil {
+		for _, image := range dg7.Images {
+			summary.SignatureImages = append(summary.SignatureImages, newImageData(image.Image))
+		}
+	}
+
+	if dg16 != nil {
+		summary.PersonsToNotify = dg16.PersonsToNotify
+	}
+
+	return summary
+}

--- a/document/document_summary_test.go
+++ b/document/document_summary_test.go
@@ -1,0 +1,298 @@
+package document
+
+import (
+	"testing"
+
+	"github.com/gmrtd/gmrtd/mrz"
+	"github.com/gmrtd/gmrtd/utils"
+)
+
+var jpegTestBytes []byte = utils.HexToBytes("ffd8ffe000104a46494600010100000100010000ffdb004300ffdb004301010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101ffc0000b080001000101011100ffc40014000100000000000000000000000000000000ffc40014100100000000000000000000000000000000ffda0008010100003f00d2cf20ffd9")
+
+func TestResolveCountry(t *testing.T) {
+	info, err := ResolveCountry("FRA")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if info.Alpha2 != "FR" || info.Alpha3 != "FRA" || info.Name != "France" {
+		t.Errorf("unexpected CountryInfo: %+v", info)
+	}
+}
+
+func TestResolveCountryGermanySpecialCase(t *testing.T) {
+	info, err := ResolveCountry("D")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if info.Alpha2 != "DE" || info.Alpha3 != "DEU" || info.Name != "Germany" {
+		t.Errorf("unexpected CountryInfo: %+v", info)
+	}
+}
+
+func TestResolveCountryUnresolvable(t *testing.T) {
+	if _, err := ResolveCountry("UTO"); err == nil {
+		t.Error("expected error for unresolvable (fictitious) country code")
+	}
+}
+
+func TestResolveCountryTolerantFallsBackToRawAlpha3(t *testing.T) {
+	info := resolveCountryTolerant("UTO")
+	if info == nil || info.Alpha3 != "UTO" || info.Alpha2 != "" || info.Name != "" {
+		t.Errorf("resolveCountryTolerant(UTO) = %+v, want {Alpha3:UTO}", info)
+	}
+}
+
+func TestResolveCountryTolerantResolvesKnownCode(t *testing.T) {
+	info := resolveCountryTolerant("FRA")
+	if info == nil || info.Alpha2 != "FR" || info.Alpha3 != "FRA" || info.Name != "France" {
+		t.Errorf("resolveCountryTolerant(FRA) = %+v", info)
+	}
+}
+
+func TestBuildIdentityAttributesNilDocument(t *testing.T) {
+	summary := buildIdentityAttributes(&Document{})
+
+	if summary == nil {
+		t.Fatal("expected non-nil IdentityAttributes even when no DGs are present")
+	}
+	if summary.Name != nil || summary.DateOfBirth != "" || len(summary.FaceImages) != 0 {
+		t.Errorf("expected an empty summary, got %+v", summary)
+	}
+}
+
+func TestBuildIdentityAttributesSampleDocument(t *testing.T) {
+	doc, err := SampleDocument()
+	if err != nil {
+		t.Fatalf("SampleDocument error: %s", err)
+	}
+
+	summary := buildIdentityAttributes(doc)
+
+	if summary.DocumentCode != "I" {
+		t.Errorf("DocumentCode = %q, want %q", summary.DocumentCode, "I")
+	}
+	if summary.DocumentNumber != "D23145890" {
+		t.Errorf("DocumentNumber = %q, want %q", summary.DocumentNumber, "D23145890")
+	}
+	if summary.Sex != "F" {
+		t.Errorf("Sex = %q, want %q", summary.Sex, "F")
+	}
+
+	// DG11's NameOfHolder wins over DG1 MRZ's, but the raw MRZ name is still surfaced
+	if summary.Name == nil || summary.Name.Primary != "SMITH" || summary.Name.Secondary != "JOHN J" {
+		t.Errorf("Name = %+v, want SMITH/JOHN J (DG11 should win over DG1 MRZ)", summary.Name)
+	}
+	if summary.NameMrzRaw == nil || summary.NameMrzRaw.Primary != "ERIKSSON" || summary.NameMrzRaw.Secondary != "ANNA MARIA" {
+		t.Errorf("NameMrzRaw = %+v, want ERIKSSON/ANNA MARIA (DG1 MRZ value)", summary.NameMrzRaw)
+	}
+
+	// DG11 sample has no FullDateOfBirth tag, so DOB falls back to the raw DG1 MRZ value
+	// (740812) - no century is guessed
+	if summary.DateOfBirth != "740812" {
+		t.Errorf("DateOfBirth = %q, want %q", summary.DateOfBirth, "740812")
+	}
+	if summary.DateOfBirthMrzRaw != "740812" {
+		t.Errorf("DateOfBirthMrzRaw = %q, want %q", summary.DateOfBirthMrzRaw, "740812")
+	}
+	if summary.DateOfBirthDg11Raw != "" {
+		t.Errorf("DateOfBirthDg11Raw = %q, want empty (sample has no FullDateOfBirth tag)", summary.DateOfBirthDg11Raw)
+	}
+
+	// DG1 MRZ is DateOfExpiry's only source, so both fields hold the same raw value
+	// (120415) - no century is guessed
+	if summary.DateOfExpiry != "120415" {
+		t.Errorf("DateOfExpiry = %q, want %q", summary.DateOfExpiry, "120415")
+	}
+	if summary.DateOfExpiryMrzRaw != "120415" {
+		t.Errorf("DateOfExpiryMrzRaw = %q, want %q", summary.DateOfExpiryMrzRaw, "120415")
+	}
+
+	// DG1's fictitious "UTO" issuing-state/nationality cannot be resolved to an
+	// alpha-2/name, but the raw alpha-3 code is still surfaced
+	if summary.IssuingState == nil || summary.IssuingState.Alpha3 != "UTO" || summary.IssuingState.Alpha2 != "" || summary.IssuingState.Name != "" {
+		t.Errorf("IssuingState = %+v, want {Alpha3:UTO} (fictitious 'UTO' code)", summary.IssuingState)
+	}
+	if summary.Nationality == nil || summary.Nationality.Alpha3 != "UTO" || summary.Nationality.Alpha2 != "" || summary.Nationality.Name != "" {
+		t.Errorf("Nationality = %+v, want {Alpha3:UTO} (fictitious 'UTO' code)", summary.Nationality)
+	}
+
+	if len(summary.PlaceOfBirth) != 2 || summary.PlaceOfBirth[0] != "ANYTOWN" {
+		t.Errorf("PlaceOfBirth = %v", summary.PlaceOfBirth)
+	}
+	if summary.Telephone != "16125551212" {
+		t.Errorf("Telephone = %q", summary.Telephone)
+	}
+	if summary.Profession != "TRAVEL AGENT" {
+		t.Errorf("Profession = %q", summary.Profession)
+	}
+
+	if len(summary.FaceImages) != 1 || summary.FaceImages[0].Format != utils.ImageFormatJPEG {
+		t.Errorf("FaceImages = %+v", summary.FaceImages)
+	}
+	if len(summary.SignatureImages) != 1 || summary.SignatureImages[0].Format != utils.ImageFormatJPEG {
+		t.Errorf("SignatureImages = %+v", summary.SignatureImages)
+	}
+
+	if len(summary.PersonsToNotify) != 2 {
+		t.Fatalf("PersonsToNotify = %d entries, want 2", len(summary.PersonsToNotify))
+	}
+	if summary.PersonsToNotify[0].Name == nil || summary.PersonsToNotify[0].Name.Primary != "SMITH" {
+		t.Errorf("PersonsToNotify[0] = %+v", summary.PersonsToNotify[0])
+	}
+}
+
+func TestBuildIdentityAttributesDobPrecedenceDg11WinsOverMrz(t *testing.T) {
+	doc := &Document{}
+	doc.Mf.Lds1.Dg1 = &DG1{Mrz: &mrz.MRZ{DateOfBirth: "740812"}}
+	doc.Mf.Lds1.Dg11 = &DG11{Details: PersonDetails{FullDateOfBirth: "20210915"}}
+
+	summary := buildIdentityAttributes(doc)
+
+	// resolved DOB favours DG11, but both raw sources remain independently visible
+	if summary.DateOfBirth != "20210915" {
+		t.Errorf("DateOfBirth = %q, want %q (DG11 FullDateOfBirth should win over MRZ)", summary.DateOfBirth, "20210915")
+	}
+	if summary.DateOfBirthMrzRaw != "740812" {
+		t.Errorf("DateOfBirthMrzRaw = %q, want %q", summary.DateOfBirthMrzRaw, "740812")
+	}
+	if summary.DateOfBirthDg11Raw != "20210915" {
+		t.Errorf("DateOfBirthDg11Raw = %q, want %q", summary.DateOfBirthDg11Raw, "20210915")
+	}
+}
+
+func TestBuildIdentityAttributesNamePrecedenceDg11WinsOverMrz(t *testing.T) {
+	doc := &Document{}
+	doc.Mf.Lds1.Dg1 = &DG1{Mrz: &mrz.MRZ{NameOfHolder: &mrz.MrzName{Primary: "ERIKSSON", Secondary: "ANNA MARIA"}}}
+	doc.Mf.Lds1.Dg11 = &DG11{Details: PersonDetails{NameOfHolder: &mrz.MrzName{Primary: "SMITH", Secondary: "JOHN J"}}}
+
+	summary := buildIdentityAttributes(doc)
+
+	// resolved Name favours DG11, but the raw MRZ name remains independently visible
+	if summary.Name == nil || summary.Name.Primary != "SMITH" || summary.Name.Secondary != "JOHN J" {
+		t.Errorf("Name = %+v, want SMITH/JOHN J (DG11 should win over DG1 MRZ)", summary.Name)
+	}
+	if summary.NameMrzRaw == nil || summary.NameMrzRaw.Primary != "ERIKSSON" || summary.NameMrzRaw.Secondary != "ANNA MARIA" {
+		t.Errorf("NameMrzRaw = %+v, want ERIKSSON/ANNA MARIA (DG1 MRZ value)", summary.NameMrzRaw)
+	}
+}
+
+func TestBuildIdentityAttributesMrzOnlyDobNoCenturyGuessed(t *testing.T) {
+	doc := &Document{}
+	doc.Mf.Lds1.Dg1 = &DG1{Mrz: &mrz.MRZ{DateOfBirth: "050615"}}
+
+	summary := buildIdentityAttributes(doc)
+
+	// no DG11, so DateOfBirth is the raw MRZ value as-is - gmrtd does not guess a century
+	if summary.DateOfBirth != "050615" {
+		t.Errorf("DateOfBirth = %q, want %q", summary.DateOfBirth, "050615")
+	}
+}
+
+// PersonalNumber (DG11 only) and MRZ optional data must be kept separate - MRZ optional
+// data is issuer-discretionary and should not be assumed to be a personal number.
+func TestBuildIdentityAttributesPersonalNumberNotConflatedWithMrzOptionalData(t *testing.T) {
+	doc := &Document{}
+	doc.Mf.Lds1.Dg1 = &DG1{Mrz: &mrz.MRZ{OptionalData: "SOMEDATA", OptionalData2: "MOREDATA"}}
+	doc.Mf.Lds1.Dg11 = &DG11{Details: PersonDetails{PersonalNumber: "12345678"}}
+
+	summary := buildIdentityAttributes(doc)
+
+	if summary.PersonalNumber != "12345678" {
+		t.Errorf("PersonalNumber = %q, want %q", summary.PersonalNumber, "12345678")
+	}
+	if summary.MrzOptionalData != "SOMEDATA" {
+		t.Errorf("MrzOptionalData = %q, want %q", summary.MrzOptionalData, "SOMEDATA")
+	}
+	if summary.MrzOptionalData2 != "MOREDATA" {
+		t.Errorf("MrzOptionalData2 = %q, want %q", summary.MrzOptionalData2, "MOREDATA")
+	}
+}
+
+func TestBuildIdentityAttributesDg12IssuingAuthorityDateOfIssueAndImages(t *testing.T) {
+	doc := &Document{}
+	doc.Mf.Lds1.Dg12 = &DG12{Details: DocumentDetails{
+		IssuingAuthority: "JAKARTA - AMBASSADE DE FRANCE EN INDONESIE",
+		DateOfIssue:      "20170905",
+		ImageFront:       jpegTestBytes,
+		ImageRear:        jpegTestBytes,
+	}}
+
+	summary := buildIdentityAttributes(doc)
+
+	if summary.IssuingAuthority != "JAKARTA - AMBASSADE DE FRANCE EN INDONESIE" {
+		t.Errorf("IssuingAuthority = %q", summary.IssuingAuthority)
+	}
+
+	if summary.DateOfIssue != "20170905" {
+		t.Errorf("DateOfIssue = %q, want %q", summary.DateOfIssue, "20170905")
+	}
+	if summary.DateOfIssueRaw != "20170905" {
+		t.Errorf("DateOfIssueRaw = %q, want %q", summary.DateOfIssueRaw, "20170905")
+	}
+
+	if summary.DocumentImageFront == nil || summary.DocumentImageFront.Format != utils.ImageFormatJPEG {
+		t.Errorf("DocumentImageFront = %+v", summary.DocumentImageFront)
+	}
+	if summary.DocumentImageRear == nil || summary.DocumentImageRear.Format != utils.ImageFormatJPEG {
+		t.Errorf("DocumentImageRear = %+v", summary.DocumentImageRear)
+	}
+}
+
+func TestBuildIdentityAttributesCountryResolution(t *testing.T) {
+	doc := &Document{}
+	doc.Mf.Lds1.Dg1 = &DG1{Mrz: &mrz.MRZ{IssuingState: "DEU", Nationality: "FRA"}}
+
+	summary := buildIdentityAttributes(doc)
+
+	if summary.IssuingState == nil || summary.IssuingState.Alpha2 != "DE" || summary.IssuingState.Name != "Germany" {
+		t.Errorf("IssuingState = %+v", summary.IssuingState)
+	}
+	if summary.Nationality == nil || summary.Nationality.Alpha2 != "FR" || summary.Nationality.Name != "France" {
+		t.Errorf("Nationality = %+v", summary.Nationality)
+	}
+}
+
+func TestSummaryIdentityAttributesPopulatedWhenTrusted(t *testing.T) {
+	docEx := &DocumentEx{
+		Session: Session{
+			PassiveAuthResult: &PassiveAuthResult{Success: true, Sod: NewPassiveAuth(nil)},
+		},
+	}
+	docEx.Document.Mf.Lds1.Dg1 = &DG1{Mrz: &mrz.MRZ{DocumentNumber: "D23145890"}}
+
+	summary := docEx.Summary()
+
+	if !summary.DataTrusted {
+		t.Fatal("expected DataTrusted to be true")
+	}
+	if summary.IdentityAttributes == nil {
+		t.Fatal("expected IdentityAttributes to be populated when DataTrusted is true")
+	}
+	if summary.IdentityAttributes.DocumentNumber != "D23145890" {
+		t.Errorf("IdentityAttributes.DocumentNumber = %q", summary.IdentityAttributes.DocumentNumber)
+	}
+}
+
+// IdentityAttributes still reflects the (unverified) DG data even when DataTrusted is
+// false - callers may want to inspect it for manual review, but must check DataTrusted
+// before treating it as authentic.
+func TestSummaryIdentityAttributesStillPopulatedWhenNotTrusted(t *testing.T) {
+	docEx := &DocumentEx{
+		Session: Session{
+			PassiveAuthResult: &PassiveAuthResult{Success: false},
+		},
+	}
+	docEx.Document.Mf.Lds1.Dg1 = &DG1{Mrz: &mrz.MRZ{DocumentNumber: "D23145890"}}
+
+	summary := docEx.Summary()
+
+	if summary.DataTrusted {
+		t.Fatal("expected DataTrusted to be false")
+	}
+	if summary.IdentityAttributes == nil {
+		t.Fatal("expected IdentityAttributes to still be populated even when DataTrusted is false")
+	}
+	if summary.IdentityAttributes.DocumentNumber != "D23145890" {
+		t.Errorf("IdentityAttributes.DocumentNumber = %q", summary.IdentityAttributes.DocumentNumber)
+	}
+}

--- a/document/session.go
+++ b/document/session.go
@@ -32,9 +32,6 @@ type Session struct {
 	// Passive Authentication
 	PassiveAuthErr    error              `json:"passiveAuthErr,omitempty"`
 	PassiveAuthResult *PassiveAuthResult `json:"passiveAuthResult,omitempty"`
-
-	// Summary (generated from above data)
-	Summary *DocumentSummary `json:"summary,omitempty"`
 }
 
 // ChipAuthProtocolCompleted reports whether a chip authentication protocol (PACE-CAM/CA/AA)
@@ -318,12 +315,4 @@ type PassiveAuth struct {
 
 func NewPassiveAuth(certChain [][]byte) *PassiveAuth {
 	return &PassiveAuth{CertChain: certChain}
-}
-
-// TODO - maybe we can remove from session.. and build on-demand?
-type DocumentSummary struct {
-	DataTrusted      bool           `json:"dataTrusted"`
-	ChipAuthenticity ChipAuthStatus `json:"chipAuthenticity"`
-	LdsVersion       string         `json:"ldsVersion,omitempty"`
-	UnicodeVersion   string         `json:"unicodeVersion,omitempty"`
 }

--- a/htmlreport/report_test.go
+++ b/htmlreport/report_test.go
@@ -70,10 +70,6 @@ func TestGenerateWithSession(t *testing.T) {
 				Sod:     document.NewPassiveAuth([][]byte{certDer}),
 				CardSec: document.NewPassiveAuth([][]byte{certDer}),
 			},
-			Summary: &document.DocumentSummary{
-				DataTrusted:      true,
-				ChipAuthenticity: document.CHIP_AUTH_STATUS_CA,
-			},
 		},
 	}
 
@@ -83,6 +79,77 @@ func TestGenerateWithSession(t *testing.T) {
 	}
 	if buf == nil || buf.Len() == 0 {
 		t.Fatal("expected non-empty output")
+	}
+}
+
+// sampleDocEx builds a DocumentEx from document.SampleDocument (DG1/DG2/DG7/DG11/DG12/DG16
+// worked-example data) with the given PassiveAuthResult success, for exercising the Person
+// Summary section of the report.
+func sampleDocEx(t *testing.T, passiveAuthSuccess bool) *document.DocumentEx {
+	t.Helper()
+
+	doc, err := document.SampleDocument()
+	if err != nil {
+		t.Fatalf("SampleDocument error: %s", err)
+	}
+
+	return &document.DocumentEx{
+		Document: *doc,
+		Session: document.Session{
+			PassiveAuthResult: &document.PassiveAuthResult{Success: passiveAuthSuccess},
+		},
+	}
+}
+
+func TestGenerateWithSessionIdentityAttributesTrusted(t *testing.T) {
+	docEx := sampleDocEx(t, true)
+
+	buf, err := Generate(docEx, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "<h2>Identity Attributes</h2>") {
+		t.Error("expected Identity Attributes section")
+	}
+	if !strings.Contains(out, "D23145890") {
+		t.Error("expected Document Number in output")
+	}
+	if !strings.Contains(out, "SMITH") {
+		t.Error("expected Name in output")
+	}
+	if !strings.Contains(out, `src="data:image/jpeg;base64,`) {
+		t.Error("expected an embedded face/signature image")
+	}
+	if !strings.Contains(out, "20020101") {
+		t.Error("expected a Persons To Notify row")
+	}
+	if strings.Contains(out, "Not cryptographically verified") {
+		t.Error("did not expect the untrusted-data warning when PassiveAuthResult.Success is true")
+	}
+	if !strings.Contains(out, "<h2>JSON</h2>") {
+		t.Error("expected a JSON section under Summary")
+	}
+	if !strings.Contains(out, `&#34;documentNumber&#34;: &#34;D23145890&#34;`) {
+		t.Error("expected the Summary JSON to include the marshaled documentNumber field")
+	}
+}
+
+func TestGenerateWithSessionIdentityAttributesUntrusted(t *testing.T) {
+	docEx := sampleDocEx(t, false)
+
+	buf, err := Generate(docEx, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "D23145890") {
+		t.Error("expected Person data to still be surfaced when untrusted")
+	}
+	if !strings.Contains(out, "Not cryptographically verified") {
+		t.Error("expected the untrusted-data warning when PassiveAuthResult.Success is false")
 	}
 }
 

--- a/htmlreport/templates/dg16.gohtml
+++ b/htmlreport/templates/dg16.gohtml
@@ -3,7 +3,7 @@
 <h2>DG16 <sub>Person(s) to Notify</sub></h2>
 {{if .}}
 {{template "fileHexAndTlv" .RawData}}
-{{/* TODO - output persons to notify */}}
+{{template "personsToNotify" .PersonsToNotify}}
 {{else}}
 <i>No data</i>
 {{end}}

--- a/htmlreport/templates/output.gohtml
+++ b/htmlreport/templates/output.gohtml
@@ -591,19 +591,59 @@ document.addEventListener('DOMContentLoaded', () => {
 </pre></div>
 {{end}}
 
+{{define "personsToNotify"}}
+{{if .}}
+<div>
+<table class="striped">
+  <thead>
+    <tr>
+      <th>Date Recorded</th>
+      <th>Name</th>
+      <th>Telephone</th>
+      <th>Address</th>
+    </tr>
+  </thead>
+  <tbody>
+    {{range .}}
+    <tr>
+      <td>{{.DateRecorded}}</td>
+      <td>{{.Name}}</td>
+      <td>{{.Telephone}}</td>
+      <td>{{.Address}}</td>
+    </tr>
+    {{end}}
+  </tbody>
+</table>
+</div>
+{{else}}
+<i>No data</i>
+{{end}}
+{{end}}
+
+{{define "identityAttributesImage"}}
+<h4>Image size (bytes): {{len .Data}}</h4>
+<img src="data:{{.Format}};base64, {{.Data | BytesToBase64}}" />
+<br/>
+{{end}}
+
+{{define "identityAttributesImages"}}
+{{range .}}
+{{template "identityAttributesImage" .}}
+{{end}}
+{{end}}
+
 <h1><a href="https://github.com/gmrtd/gmrtd">GMRTD</a> <sub>(v{{ GmrtdVersion }})</sub></h1>
 
 <div>
-<a href="#session">Session</a> | <a href="#document">Document</a> | <a href="#apdu">APDU</a> | <a href="#json">JSON</a> | <a href="#cbor">CBOR</a>
+<a href="#summary">Summary</a> | <a href="#session">Session</a> | <a href="#document">Document</a> | <a href="#apdu">APDU</a> | <a href="#json">JSON</a> | <a href="#cbor">CBOR</a>
 </div>
 
 <br/>
 
-<div id="session">
-<h1>Session</h1>
+<div id="summary">
+<h1>Summary</h1>
 
-<h2>Summary</h2>
-{{if .Session.Summary}}
+<h2>Trust</h2>
 <div>
 <table class="striped">
   <thead>
@@ -615,26 +655,182 @@ document.addEventListener('DOMContentLoaded', () => {
   <tbody>
     <tr>
       <td>Trusted Data</td>
-      <td>{{.Session.Summary.DataTrusted}}</td>
+      <td>{{.Summary.DataTrusted}}</td>
     </tr>
     <tr>
       <td>Authentic Chip</td>
-      <td>{{.Session.Summary.ChipAuthenticity}}</td>
+      <td>{{.Summary.ChipAuthenticity}}</td>
     </tr>
     <tr>
       <td>LDS version</td>
-      <td>{{.Session.Summary.LdsVersion}}</td>
+      <td>{{.Summary.LdsVersion}}</td>
     </tr>
     <tr>
       <td>Unicode version</td>
-      <td>{{.Session.Summary.UnicodeVersion}}</td>
+      <td>{{.Summary.UnicodeVersion}}</td>
     </tr>
   </tbody>
 </table>
 </div>
-{{else}}
-<i>Missing Summary! DO NOT TRUST this Document!</i>
+
+<h2>Identity Attributes</h2>
+{{if .Summary.IdentityAttributes}}
+{{if not .Summary.DataTrusted}}
+<p><i>&#9888; Not cryptographically verified - see "Trusted Data" above. This data is sourced
+from the document but has not been authenticated, and may be forged or tampered with.</i></p>
 {{end}}
+<div>
+<table class="striped">
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Document Code</td>
+      <td>{{.Summary.IdentityAttributes.DocumentCode}}</td>
+    </tr>
+    <tr>
+      <td>Document Number</td>
+      <td>{{.Summary.IdentityAttributes.DocumentNumber}}</td>
+    </tr>
+    <tr>
+      <td>Sex</td>
+      <td>{{.Summary.IdentityAttributes.Sex}}</td>
+    </tr>
+    <tr>
+      <td>Issuing State</td>
+      <td>{{.Summary.IdentityAttributes.IssuingState}}</td>
+    </tr>
+    <tr>
+      <td>Nationality</td>
+      <td>{{.Summary.IdentityAttributes.Nationality}}</td>
+    </tr>
+    <tr>
+      <td>Name</td>
+      <td>{{.Summary.IdentityAttributes.Name}}</td>
+    </tr>
+    <tr>
+      <td>Name (MRZ, raw)</td>
+      <td>{{.Summary.IdentityAttributes.NameMrzRaw}}</td>
+    </tr>
+    <tr>
+      <td>Other Names</td>
+      <td>{{.Summary.IdentityAttributes.OtherNames}}</td>
+    </tr>
+    <tr>
+      <td>Date Of Birth</td>
+      <td>{{.Summary.IdentityAttributes.DateOfBirth}}</td>
+    </tr>
+    <tr>
+      <td>Date Of Birth (MRZ, raw)</td>
+      <td>{{.Summary.IdentityAttributes.DateOfBirthMrzRaw}}</td>
+    </tr>
+    <tr>
+      <td>Date Of Birth (DG11, raw)</td>
+      <td>{{.Summary.IdentityAttributes.DateOfBirthDg11Raw}}</td>
+    </tr>
+    <tr>
+      <td>Date Of Expiry</td>
+      <td>{{.Summary.IdentityAttributes.DateOfExpiry}}</td>
+    </tr>
+    <tr>
+      <td>Date Of Expiry (MRZ, raw)</td>
+      <td>{{.Summary.IdentityAttributes.DateOfExpiryMrzRaw}}</td>
+    </tr>
+    <tr>
+      <td>Place Of Birth</td>
+      <td>{{.Summary.IdentityAttributes.PlaceOfBirth}}</td>
+    </tr>
+    <tr>
+      <td>Address</td>
+      <td>{{.Summary.IdentityAttributes.Address}}</td>
+    </tr>
+    <tr>
+      <td>Telephone</td>
+      <td>{{.Summary.IdentityAttributes.Telephone}}</td>
+    </tr>
+    <tr>
+      <td>Profession</td>
+      <td>{{.Summary.IdentityAttributes.Profession}}</td>
+    </tr>
+    <tr>
+      <td>Title</td>
+      <td>{{.Summary.IdentityAttributes.Title}}</td>
+    </tr>
+    <tr>
+      <td>Personal Number</td>
+      <td>{{.Summary.IdentityAttributes.PersonalNumber}}</td>
+    </tr>
+    <tr>
+      <td>MRZ Optional Data</td>
+      <td>{{.Summary.IdentityAttributes.MrzOptionalData}}</td>
+    </tr>
+    <tr>
+      <td>MRZ Optional Data 2</td>
+      <td>{{.Summary.IdentityAttributes.MrzOptionalData2}}</td>
+    </tr>
+    <tr>
+      <td>Issuing Authority</td>
+      <td>{{.Summary.IdentityAttributes.IssuingAuthority}}</td>
+    </tr>
+    <tr>
+      <td>Date Of Issue</td>
+      <td>{{.Summary.IdentityAttributes.DateOfIssue}}</td>
+    </tr>
+    <tr>
+      <td>Date Of Issue (raw)</td>
+      <td>{{.Summary.IdentityAttributes.DateOfIssueRaw}}</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+<h3>Face Image(s)</h3>
+{{if .Summary.IdentityAttributes.FaceImages}}
+{{template "identityAttributesImages" .Summary.IdentityAttributes.FaceImages}}
+{{else}}
+<i>No data</i>
+{{end}}
+
+<h3>Signature Image(s)</h3>
+{{if .Summary.IdentityAttributes.SignatureImages}}
+{{template "identityAttributesImages" .Summary.IdentityAttributes.SignatureImages}}
+{{else}}
+<i>No data</i>
+{{end}}
+
+<h3>Document Image (Front)</h3>
+{{if .Summary.IdentityAttributes.DocumentImageFront}}
+{{template "identityAttributesImage" .Summary.IdentityAttributes.DocumentImageFront}}
+{{else}}
+<i>No data</i>
+{{end}}
+
+<h3>Document Image (Rear)</h3>
+{{if .Summary.IdentityAttributes.DocumentImageRear}}
+{{template "identityAttributesImage" .Summary.IdentityAttributes.DocumentImageRear}}
+{{else}}
+<i>No data</i>
+{{end}}
+
+<h3>Persons To Notify</h3>
+{{template "personsToNotify" .Summary.IdentityAttributes.PersonsToNotify}}
+
+{{else}}
+<i>No data</i>
+{{end}}
+
+<h2>JSON</h2>
+<div><pre>
+{{ IndentedJson .Summary }}
+</pre></div>
+</div>
+
+<div id="session">
+<h1>Session</h1>
 
 <h2>Chip Activation Response</h2>
 {{if .Session.ChipActivationRsp}}

--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gmrtd/gmrtd/cms"
 	"github.com/gmrtd/gmrtd/document"
 	"github.com/gmrtd/gmrtd/internal/version"
-	"github.com/gmrtd/gmrtd/iso3166"
 	"github.com/gmrtd/gmrtd/iso7816"
 	"github.com/gmrtd/gmrtd/oid"
 	"github.com/gmrtd/gmrtd/passiveauth"
@@ -202,17 +201,12 @@ func (r *Reader) ReadDocument(password *MrtdPassword, atr []byte, ats []byte) (d
 // CountryName returns the country name for an MRZ alpha-3 country code.
 // Handles ICAO 9303 quirks such as Germany's special code "D" (mapped to "DEU").
 func CountryName(mrzAlpha3 string) (string, error) {
-	// special handling for Germany per ICAO9303p3 (5. CODES FOR NATIONALITY...)
-	if mrzAlpha3 == "D" {
-		mrzAlpha3 = "DEU"
+	info, err := document.ResolveCountry(mrzAlpha3)
+	if err != nil {
+		return "", fmt.Errorf("[CountryName] %w", err)
 	}
 
-	country := iso3166.ByAlpha3(mrzAlpha3)
-	if country == nil {
-		return "", fmt.Errorf("[CountryName] unable to resolve alpha-3 country code (%s)", mrzAlpha3)
-	}
-
-	return country.Name, nil
+	return info.Name, nil
 }
 
 // OidDesc returns the description associated with an OID string (e.g. "0.4.0.127.0.7").
@@ -290,8 +284,6 @@ func NewSampleDocument() (*Document, error) {
 
 	documentEx.Session.PassiveAuthResult, documentEx.Session.PassiveAuthErr = passiveauth.PassiveAuth(sampleDoc, certPool)
 
-	documentEx.GenerateSummary()
-
 	return &Document{documentEx: documentEx}, nil
 }
 
@@ -301,6 +293,19 @@ func (doc *Document) DocumentExJson() (jsonData []byte, err error) {
 	}
 
 	jsonData, err = json.Marshal(doc.documentEx)
+
+	return jsonData, err
+}
+
+// SummaryJson returns the document's current DocumentSummary (see
+// document.DocumentEx.Summary) as JSON. It is computed fresh on every call from the
+// document/session state, rather than being carried in DocumentExJson's output.
+func (doc *Document) SummaryJson() (jsonData []byte, err error) {
+	if doc.documentEx == nil {
+		return nil, fmt.Errorf("[SummaryJson] No document available")
+	}
+
+	jsonData, err = json.Marshal(doc.documentEx.Summary())
 
 	return jsonData, err
 }

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -310,6 +310,17 @@ func TestDocumentExJsonError(t *testing.T) {
 	}
 }
 
+func TestSummaryJsonError(t *testing.T) {
+	// error expected as we attempt to get Summary-Json before ReadDocument
+
+	doc := &Document{}
+
+	_, err := doc.SummaryJson()
+	if err == nil {
+		t.Errorf("error expected")
+	}
+}
+
 type PanicTransceiver struct {
 }
 
@@ -406,8 +417,18 @@ func TestNewSampleDocument(t *testing.T) {
 	if session.PassiveAuthErr == nil {
 		t.Errorf("expected PassiveAuthErr to be set")
 	}
-	if session.Summary == nil || session.Summary.DataTrusted {
+
+	summary := doc.documentEx.Summary()
+	if summary == nil || summary.DataTrusted {
 		t.Errorf("expected Summary.DataTrusted to be false")
+	}
+
+	summaryJson, err := doc.SummaryJson()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(summaryJson) < 1 {
+		t.Error("expected some Summary JSON data")
 	}
 
 	json, err := doc.DocumentExJson()

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -172,7 +172,6 @@ func (reader *Reader) ReadDocument(password *password.Password, atr []byte, ats 
 		performChipAuthentication,
 		verifyDocument,
 		performPassiveAuthentication,
-		calculateDocumentSummary,
 	)
 	if err != nil {
 		return state.docEx, reader.nfc.ApduLog(), fmt.Errorf("[ReadDocument] runSteps error: %w", err)
@@ -404,10 +403,5 @@ func verifyDocument(reader *Reader, state *ReaderState) error {
 	if state.docEx.Session.DocumentVerifyErr != nil {
 		slog.Error("Document.Verify", "error", state.docEx.Session.DocumentVerifyErr)
 	}
-	return nil
-}
-
-func calculateDocumentSummary(_ *Reader, state *ReaderState) error {
-	state.docEx.GenerateSummary()
 	return nil
 }

--- a/reader/reader_test.go
+++ b/reader/reader_test.go
@@ -713,28 +713,6 @@ func TestPerformPassiveAuthenticationBadSignatureErr(t *testing.T) {
 	}
 }
 
-func TestCalculateDocumentSummaryEmptyDoc(t *testing.T) {
-	var status MockStatus
-	var nfc *iso7816.NfcSession = iso7816.NewNfcSession(&PanicTransceiver{P: "will panic if called"})
-	var reader *Reader = NewReader(&status, nfc, EmptyCscaTrustStore(t))
-	var password *password.Password = password.NewPasswordNil()
-	var state *ReaderState = NewReaderState(nil, nil, password)
-
-	var err error
-
-	err = calculateDocumentSummary(reader, state)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-
-	// note: summary should be generated even for empty document, but will indicate no trust for data/chip
-	expSummary := &document.DocumentSummary{DataTrusted: false, ChipAuthenticity: document.CHIP_AUTH_STATUS_NONE}
-
-	if !reflect.DeepEqual(expSummary, state.docEx.Session.Summary) {
-		t.Fatalf("Summary differs to expected [Exp] %+v [Act] %+v", expSummary, state.docEx.Session.Summary)
-	}
-}
-
 func TestVerifyDocumentEmptyDocErr(t *testing.T) {
 	// note: empty document will fail verification, but the step itself is soft-fail -
 	// the error is recorded on the session, not returned (see Session.DocumentVerifyErr)

--- a/utils/image_utils.go
+++ b/utils/image_utils.go
@@ -5,9 +5,17 @@ import (
 	"log/slog"
 )
 
-// determines whether the data constitutes an image
-// return: 'true' if image detected, otherwise 'false'
-func IsImage(imageBytes []byte) bool {
+type ImageFormat string
+
+const (
+	ImageFormatJPEG     ImageFormat = "image/jpeg"
+	ImageFormatJPEG2000 ImageFormat = "image/jp2"
+)
+
+// DetectImageFormat inspects the magic bytes of imageBytes and reports the recognized
+// image format. The second return value is 'false' if the bytes don't match a known
+// image format.
+func DetectImageFormat(imageBytes []byte) (ImageFormat, bool) {
 	/*
 	* Classic JPEG (JFIF/Exif/SPIF/Adobe) files begin with these bytes:
 	* 	- FF D8 — SOI
@@ -19,7 +27,7 @@ func IsImage(imageBytes []byte) bool {
 		prefixJpeg := HexToBytes("ffd8ff")
 
 		if bytes.HasPrefix(imageBytes, prefixJpeg) {
-			return true
+			return ImageFormatJPEG, true
 		}
 	}
 
@@ -34,12 +42,19 @@ func IsImage(imageBytes []byte) bool {
 
 		if bytes.HasPrefix(imageBytes, prefixJp2Bitmap) ||
 			bytes.HasPrefix(imageBytes, prefixJp2CodestreamBitmap) {
-			return true
+			return ImageFormatJPEG2000, true
 		}
 
 	}
 
 	slog.Debug("Unknown image type", "prefix", SafePrefix(imageBytes, 10))
 
-	return false
+	return "", false
+}
+
+// determines whether the data constitutes an image
+// return: 'true' if image detected, otherwise 'false'
+func IsImage(imageBytes []byte) bool {
+	_, ok := DetectImageFormat(imageBytes)
+	return ok
 }

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -68,7 +68,5 @@ func (v *Verifier) Verify(data []byte) (*document.DocumentEx, error) {
 
 	docEx.Session.DocumentVerifyErr = doc.Verify()
 
-	docEx.GenerateSummary()
-
 	return &docEx, nil
 }

--- a/verifier/verifier_test.go
+++ b/verifier/verifier_test.go
@@ -135,7 +135,7 @@ func TestVerifyDocumentVerifyErrMissingDG1(t *testing.T) {
 		t.Fatalf("expected DocumentVerifyErr to be set when mandatory DG1/SOD are missing")
 	}
 
-	if result.Session.Summary == nil || result.Session.Summary.DataTrusted {
+	if summary := result.Summary(); summary == nil || summary.DataTrusted {
 		t.Errorf("expected DataTrusted to be false when DocumentVerifyErr is set")
 	}
 }


### PR DESCRIPTION
## Summary

- Replaces the cached `Session.Summary` (populated by `DocumentEx.GenerateSummary()`, called as a reader/verifier pipeline step) with `DocumentEx.Summary()`, computed fresh on every call from the current Document/Session state. Removes the now-unneeded `calculateDocumentSummary` reader step.
- Adds `IdentityAttributes` to `DocumentSummary`: a flattened, client-friendly view of the data spread across DG1 (MRZ)/DG2/DG7/DG11/DG12/DG16, with documented field precedence where multiple DGs carry the same data (e.g. DG11 name/DOB wins over DG1 MRZ when present, with both raw sources still surfaced separately). Populated regardless of `DataTrusted`, since callers may want to inspect unverified data for manual review.
- Deduplicates MRZ alpha-3 -> country resolution (including the Germany "D" -> "DEU" special case) into `document.ResolveCountry`/`resolveCountryTolerant`, previously duplicated in `document/dg1.go` and `mobile/mobile.go`.
- Adds `utils.DetectImageFormat`, returning the detected `ImageFormat` (JPEG/JPEG2000) rather than just a bool; `IsImage` is now implemented on top of it.
- Adds an "Identity Attributes" section to the HTML report (with an untrusted-data warning when `DataTrusted` is false), and implements the previously-stubbed Persons-to-Notify (DG16) table.
- Adds `mobile.Document.SummaryJson()` for mobile bindings to fetch the summary as JSON.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1`
- [x] `gofmt -l` on new/changed files (no issues introduced by this diff)
- [x] Verified no remaining references to the removed `GenerateSummary`/`Session.Summary` API