### PR TITLE
fix: accept legacy ICAO and Sdu (NL) ldsSecurityObject content-type OIDs

### DIFF
--- a/document/sod.go
+++ b/document/sod.go
@@ -128,6 +128,12 @@ func parseSignedDataWithDecodeEncodeRetry(data []byte) (*cms.SignedData, error) 
 func isValidEContentType(eContentOid asn1.ObjectIdentifier) bool {
 	if eContentOid.Equal(oid.OidLdsSecurityObject) {
 		return true
+	} else if eContentOid.Equal(oid.OidLdsSecurityObjectLegacy) {
+		// legacy ICAO icao(27) arc; observed on Belgian/French MRTDs
+		return true
+	} else if eContentOid.Equal(oid.OidLdsSecurityObjectSdu) {
+		// Sdu Identification (NL) variant
+		return true
 	} else if eContentOid.Equal(oid.OidIdData) {
 		// observed on China passport
 		return true

--- a/document/sod_test.go
+++ b/document/sod_test.go
@@ -2,12 +2,32 @@ package document
 
 import (
 	"bytes"
+	"encoding/asn1"
 	"strings"
 	"testing"
 
 	cms "github.com/gmrtd/gmrtd/cms"
+	"github.com/gmrtd/gmrtd/oid"
 	"github.com/gmrtd/gmrtd/utils"
 )
+
+func TestIsValidEContentType(t *testing.T) {
+	testCases := []struct {
+		oid asn1.ObjectIdentifier
+		exp bool
+	}{
+		{oid: oid.OidLdsSecurityObject, exp: true},       // 2.23.136.1.1.1 (standard ICAO)
+		{oid: oid.OidLdsSecurityObjectLegacy, exp: true}, // 1.3.27.1.1.1 (legacy ICAO, BE/FR)
+		{oid: oid.OidLdsSecurityObjectSdu, exp: true},    // 1.2.528.1.1006.1.20.1 (Sdu/NL)
+		{oid: oid.OidIdData, exp: true},                  // 1.2.840.113549.1.7.1 (China passport)
+		{oid: oid.OidSignedData, exp: false},             // unrelated OID
+	}
+	for _, tc := range testCases {
+		if act := isValidEContentType(tc.oid); act != tc.exp {
+			t.Errorf("isValidEContentType(%s): expected %t, got %t", tc.oid.String(), tc.exp, act)
+		}
+	}
+}
 
 func TestNewSodInvalidCases(t *testing.T) {
 	testCases := []struct {

--- a/oid/oid.go
+++ b/oid/oid.go
@@ -77,6 +77,7 @@ var (
 	OidPaceEcdhCamAesCbcCmac192         = asn1.ObjectIdentifier{0, 4, 0, 127, 0, 7, 2, 2, 4, 6, 3}
 	OidPaceEcdhCamAesCbcCmac256         = asn1.ObjectIdentifier{0, 4, 0, 127, 0, 7, 2, 2, 4, 6, 4}
 	OidSecurityObject                   = asn1.ObjectIdentifier{0, 4, 0, 127, 0, 7, 3, 2, 1}
+	OidLdsSecurityObjectSdu             = asn1.ObjectIdentifier{1, 2, 528, 1, 1006, 1, 20, 1} // Sdu Identification (NL) variant of ldsSecurityObject content-type
 	OidPrimeField                       = asn1.ObjectIdentifier{1, 2, 840, 10045, 1, 1}
 	OidEcPublicKey                      = asn1.ObjectIdentifier{1, 2, 840, 10045, 2, 1}
 	OidPrime192v1                       = asn1.ObjectIdentifier{1, 2, 840, 10045, 3, 1, 1}
@@ -102,6 +103,7 @@ var (
 	OidSigningTime                      = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 5}
 	OidHashAlgorithmMD5                 = asn1.ObjectIdentifier{1, 2, 840, 113549, 2, 5}
 	OidHashAlgorithmSHA1                = asn1.ObjectIdentifier{1, 3, 14, 3, 2, 26}
+	OidLdsSecurityObjectLegacy          = asn1.ObjectIdentifier{1, 3, 27, 1, 1, 1} // legacy ICAO icao(27) arc for ldsSecurityObject; seen on Belgian/French MRTDs
 	OidEfDir                            = asn1.ObjectIdentifier{1, 3, 27, 1, 1, 13}
 	OidBrainpoolP192r1                  = asn1.ObjectIdentifier{1, 3, 36, 3, 3, 2, 8, 1, 1, 3}
 	OidBrainpoolP224r1                  = asn1.ObjectIdentifier{1, 3, 36, 3, 3, 2, 8, 1, 1, 5}
@@ -258,6 +260,8 @@ var oidLookup = map[string]string{
 	OidIcao.String():                             "id-icao",
 	OidIcaoMrtdSecurity.String():                 "id-icao-mrtd-security",
 	OidLdsSecurityObject.String():                "ldsSecurityObject",
+	OidLdsSecurityObjectLegacy.String():          "ldsSecurityObject-legacy",
+	OidLdsSecurityObjectSdu.String():             "ldsSecurityObject-sdu",
 	OidIcaoMrtdSecurityAaProtocolObject.String(): "id-icao-mrtd-security-aaProtocolObject",
 	OidDocumentTypeList.String():                 "documentTypeList",
 }


### PR DESCRIPTION
## Describe the bug

`document.NewSOD` rejects a valid EF.SOD whose CMS `eContentType` (the encapContentInfo content type) is the legacy ICAO OID `1.3.27.1.1.1` for `ldsSecurityObject`. `isValidEContentType` (`document/sod.go`) only accepted `2.23.136.1.1.1` (`OidLdsSecurityObject`) and `1.2.840.113549.1.7.1` (`OidIdData`), so `NewSOD` failed before any signature / data-group-hash verification with:

```
[NewSOD] Incorrect ContentType (got:1.3.27.1.1.1)
```

`1.3.27.1.1.1` is the legacy `iso(1) identified-organization(3) icao(27) …` arc for the same `ldsSecurityObject` object as the modern `2.23.136.1.1.1` (`joint-iso-itu-t(2) international-organizations(23) icao(136) …`) arc. It is used by real MRTDs in the field, notably **Belgian and French** documents.

## What this changes

`isValidEContentType` now additionally accepts:

| OID | Description |
|-----|-------------|
| `1.3.27.1.1.1` | Legacy ICAO `icao(27)` arc for `ldsSecurityObject`; observed on live Belgian/French MRTDs |
| `1.2.528.1.1006.1.20.1` | Sdu Identification BV (NL) variant of the SOD content type |

Both are added as constants in `oid/oid.go` (with lookup-map descriptions), matching the reference implementation (JMRTD), which accepts these as `ICAO_LDS_SOD_ALT_OID` and `SDU_LDS_SOD_OID` respectively.

## Notes

- The outer CMS `SignedData` wrapper on the affected documents decodes as well-formed standard DER — only the inner `eContentType` uses the legacy arc, so this is a genuine encoding variant rather than a corrupted read.
- Live-document evidence is strongest for `1.3.27.1.1.1` (Belgian/French). The Sdu OID is included for parity with JMRTD; JMRTD's own comment notes it primarily from test/worked-example documents.
- Added `TestIsValidEContentType` covering all accepted OIDs and a negative case.

## References

- JMRTD `SODFile.java` defines `ICAO_LDS_SOD_ALT_OID = "1.3.27.1.1.1"` ("Seen in live French and Belgian MRTDs") and `SDU_LDS_SOD_OID = "1.2.528.1.1006.1.20.1"`, accepting both as valid content types: https://github.com/E3V3A/JMRTD/blob/master/jmrtd/src/org/jmrtd/lds/SODFile.java
- OID registry entry for `1.3.27.1.1.1` (ASN.1 module `LDSSecurityObject`, arc `icao(27)`): https://oid-base.com/get/1.3.27.1.1.1