### PR TITLE
fix: trim empty strings from DG11 fields caused by leading/trailing/repeated filler chars

### DIFF
--- a/document/dg11.go
+++ b/document/dg11.go
@@ -150,6 +150,12 @@ func (details *PersonDetails) processTag5F0F(parentNode tlv.TlvNode) error {
 	return nil
 }
 
+// splits on '<' filler chars, discarding any empty strings caused by
+// leading/trailing/repeated separators (e.g. seen on French passports)
+func splitFieldsFiltered(s string) []string {
+	return strings.FieldsFunc(s, func(r rune) bool { return r == '<' })
+}
+
 // processes the 'tag', getting the data from the TLV and populating PersonDetails
 func (details *PersonDetails) processTag(tag tlv.TlvTag, node tlv.TlvNode) error {
 	value := node.NodeByTag(tag).Value()
@@ -172,9 +178,9 @@ func (details *PersonDetails) processTag(tag tlv.TlvTag, node tlv.TlvNode) error
 		// should be 8 bytes (YYYYMMDD) but we've also seen 4 bytes (BCD) - e.g. Malaysia passport
 		details.FullDateOfBirth = parseDateYYYYMMDD(value)
 	case 0x5F11:
-		details.PlaceOfBirth = strings.Split(string(value), "<")
+		details.PlaceOfBirth = splitFieldsFiltered(string(value))
 	case 0x5F42:
-		details.Address = strings.Split(string(value), "<")
+		details.Address = splitFieldsFiltered(string(value))
 	case 0x5F12:
 		details.Telephone = string(value)
 	case 0x5F13:
@@ -187,7 +193,7 @@ func (details *PersonDetails) processTag(tag tlv.TlvTag, node tlv.TlvNode) error
 		// image data
 		details.ProofOfCitizenship = value
 	case 0x5F17:
-		details.OtherTravelDocuments = strings.Split(string(value), "<")
+		details.OtherTravelDocuments = splitFieldsFiltered(string(value))
 	case 0x5F18:
 		details.CustodyInformation = mrz.DecodeValue(string(value))
 	default:

--- a/document/dg11_test.go
+++ b/document/dg11_test.go
@@ -316,6 +316,30 @@ func TestProcessTagDG11(t *testing.T) {
 			tlvNode:          tlv.NewTlvConstructedNode(0x6C).AddChild(tlv.NewTlvSimpleNode(0x5F2B, utils.HexToBytes("3230313730393035"))),
 			expPersonDetails: PersonDetails{FullDateOfBirth: "20170905"},
 		},
+		{
+			// 5F42: "<1 RUE DE LA PAIX<PARIS" - leading filler char (e.g. seen on French passports)
+			// should not produce a leading empty string in the Address slice
+			name:             "5F42 Address - leading filler char",
+			tlvTag:           0x5F42,
+			tlvNode:          tlv.NewTlvConstructedNode(0x6C).AddChild(tlv.NewTlvSimpleNode(0x5F42, []byte("<1 RUE DE LA PAIX<PARIS"))),
+			expPersonDetails: PersonDetails{Address: []string{"1 RUE DE LA PAIX", "PARIS"}},
+		},
+		{
+			// 5F42: "1 RUE DE LA PAIX<PARIS<" - trailing filler char
+			// should not produce a trailing empty string in the Address slice
+			name:             "5F42 Address - trailing filler char",
+			tlvTag:           0x5F42,
+			tlvNode:          tlv.NewTlvConstructedNode(0x6C).AddChild(tlv.NewTlvSimpleNode(0x5F42, []byte("1 RUE DE LA PAIX<PARIS<"))),
+			expPersonDetails: PersonDetails{Address: []string{"1 RUE DE LA PAIX", "PARIS"}},
+		},
+		{
+			// 5F42: "1 RUE DE LA PAIX<<PARIS" - repeated filler chars between fields
+			// should not produce an empty string between the two real fields
+			name:             "5F42 Address - repeated filler chars",
+			tlvTag:           0x5F42,
+			tlvNode:          tlv.NewTlvConstructedNode(0x6C).AddChild(tlv.NewTlvSimpleNode(0x5F42, []byte("1 RUE DE LA PAIX<<PARIS"))),
+			expPersonDetails: PersonDetails{Address: []string{"1 RUE DE LA PAIX", "PARIS"}},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
### Summary
- `PersonDetails.Address`, `PlaceOfBirth`, and `OtherTravelDocuments` were populated via `strings.Split(value, "<")`, which produces empty-string elements whenever the underlying value has a leading, trailing, or repeated `<` filler character (e.g. observed on French passports, where `Address` starts with `<`).
- Replaced the raw `strings.Split` calls with a new `splitFieldsFiltered` helper built on `strings.FieldsFunc`, which splits on runs of `<` and discards empty fields, matching how MRZ filler chars are meant to be treated.

### Test plan
- [x] Added regression tests in `dg11_test.go` covering leading, trailing, and repeated (`<<`) filler chars in the `5F42` (Address) field.
- [x] `go test ./document/... -run DG11` passes, including all pre-existing DG11 tests.