### PR TITLE
fix:Concurrent use of Reader/Verifier corrupts Go heap (fatal error: bulkBarrierPreWrite)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,14 +28,14 @@ jobs:
     - name: Build
       run: go build -v ./...
     - name: Test Coverage
-      run: go test ./... -coverprofile=coverage.out
+      run: go test -race ./... -coverprofile=coverage.out
     - name: Archive code coverage results
       uses: actions/upload-artifact@v4
       with:
         name: coverage.out
         path: coverage.out
     - name: Test Result
-      run: go test ./... -json > report.json
+      run: go test -race ./... -json > report.json
     - name: Archive test report
       uses: actions/upload-artifact@v4
       with:

--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -87,7 +87,17 @@ func NewPasswordCan(can string) (*MrtdPassword, error) {
 	return &MrtdPassword{password: password.NewPasswordCan(can)}, nil
 }
 
+// Reader is not safe for concurrent use: it is a single-use, single-goroutine
+// object for driving one document read. mu guards the mutable configuration
+// fields (set via SetApduMaxLe/SkipPace/SkipImages/WithAAChallenge) and
+// serialises ReadDocument, so a Reader that a host app accidentally shares
+// and calls from multiple threads (e.g. gomobile bindings invoked from
+// several Swift/Kotlin dispatch queues) fails safe - calls queue up - rather
+// than racing on these fields and corrupting the Go heap. Callers should
+// still construct a new Reader per read rather than relying on this lock.
 type Reader struct {
+	mu sync.Mutex
+
 	status      ReaderStatus
 	transceiver Transceiver
 	maxRead     int
@@ -113,17 +123,23 @@ func (r *Reader) SetApduMaxLe(maxRead int) error {
 	if maxRead < 0 || maxRead > 65536 {
 		return fmt.Errorf("[SetApduMaxLe] maxRead must be 0 or between 1 and 65536")
 	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.maxRead = maxRead
 	return nil
 }
 
 // SkipPace configures the reader to skip PACE during document reading
 func (r *Reader) SkipPace() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.skipPace = true
 }
 
 // SkipImages configures the reader to skip image data groups (DG2, DG7)
 func (r *Reader) SkipImages() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.skipImages = true
 }
 
@@ -144,11 +160,17 @@ func (r *Reader) WithAAChallenge(challenge []byte) (*Reader, error) {
 	if len(challenge) != 8 {
 		return nil, fmt.Errorf("[WithAAChallenge] challenge must be exactly 8 bytes, got %d", len(challenge))
 	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.aaChallenge = bytes.Clone(challenge)
 	return r, nil
 }
 
 func (r *Reader) ReadDocument(password *MrtdPassword, atr []byte, ats []byte) (doc *Document, err error) {
+	// Locked for the whole call: see the Reader docstring above.
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	defer func() {
 		if e := recover(); e != nil {
 			switch x := e.(type) {
@@ -215,7 +237,13 @@ func OidDesc(oidStr string) string {
 	return oid.OidDescStr(oidStr)
 }
 
+// Verifier is not safe for concurrent use: it is a single-use,
+// single-goroutine object for verifying one piece of evidence. mu guards
+// aaChallenge (set via WithAAChallenge) and serialises Verify - see the
+// Reader docstring above for why this matters for gomobile-bound callers.
 type Verifier struct {
+	mu sync.Mutex
+
 	aaChallenge []byte
 }
 
@@ -234,11 +262,17 @@ func (v *Verifier) WithAAChallenge(challenge []byte) (*Verifier, error) {
 	if len(challenge) != 8 {
 		return nil, fmt.Errorf("[WithAAChallenge] challenge must be exactly 8 bytes, got %d", len(challenge))
 	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
 	v.aaChallenge = bytes.Clone(challenge)
 	return v, nil
 }
 
 func (v *Verifier) Verify(data []byte) (doc *Document, err error) {
+	// Locked for the whole call: see the Verifier docstring above.
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
 	certPool, err := getCscaCertPool()
 	if err != nil {
 		return nil, fmt.Errorf("[Verify] getCscaCertPool error: %w", err)

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -2,6 +2,7 @@ package mobile
 
 import (
 	"regexp"
+	"sync"
 	"testing"
 
 	"github.com/gmrtd/gmrtd/document"
@@ -454,6 +455,53 @@ func TestNewSampleDocument(t *testing.T) {
 	if len(apduLogJson) < 1 {
 		t.Error("expected some (empty-log) APDU log JSON data")
 	}
+}
+
+// Regression test for a heap-corruption crash observed under concurrent use
+// on iOS: a shared mobile.Reader's fields (maxRead/skipPace/skipImages/
+// aaChallenge) were written by the configuration methods while ReadDocument
+// read them from another goroutine, unsynchronised - exactly the kind of
+// race that manifests as a Go runtime fatal error (e.g.
+// "bulkBarrierPreWrite: unaligned arguments") rather than a clean panic. Run
+// with `go test -race` to confirm the mutex added to Reader closes the race.
+func TestReaderConcurrentAccess(t *testing.T) {
+	reader := NewReader(&testReaderStatus{}, &iso7816.StaticTransceiver{})
+
+	pass, err := NewPasswordMrz("I<UTOSTEVENSON<<PETER<JOHN<<<<<<<<<<D23145890<UTO3407127M95071227349<<<8")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = reader.SetApduMaxLe(1000)
+			reader.SkipPace()
+			reader.SkipImages()
+			_, _ = reader.WithAAChallenge(make([]byte, 8))
+			_, _ = reader.ReadDocument(pass, nil, nil) // expected to fail fast (static transceiver)
+		}()
+	}
+	wg.Wait()
+}
+
+// Regression test for the same class of race as TestReaderConcurrentAccess,
+// but for mobile.Verifier's aaChallenge field.
+func TestVerifierConcurrentAccess(t *testing.T) {
+	v := NewVerifier()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = v.WithAAChallenge(make([]byte, 8))
+			_, _ = v.Verify([]byte{0xff, 0xff, 0xff}) // expected to fail fast (invalid CBOR)
+		}()
+	}
+	wg.Wait()
 }
 
 func TestVersion(t *testing.T) {

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 
 	"github.com/gmrtd/gmrtd/activeauth"
 	"github.com/gmrtd/gmrtd/bac"
@@ -73,7 +74,17 @@ type ReaderStatus interface {
 	Status(msg string)
 }
 
+// Reader is not safe for concurrent use: it is a single-use, single-goroutine
+// object for driving one document read. The mu mutex guards the mutable
+// configuration fields below (set via SkipPace/SkipImages/WithAAChallenge)
+// and serialises ReadDocument, so a Reader that is accidentally shared and
+// called from multiple goroutines fails safe (calls queue up) rather than
+// corrupting the Go heap - see mobile.Reader for the same concern one layer
+// up, which is where callers are most likely to accidentally share an
+// instance across threads.
 type Reader struct {
+	mu sync.Mutex
+
 	status       ReaderStatus
 	nfc          *iso7816.NfcSession
 	cscaCertPool cms.CertPool
@@ -91,10 +102,14 @@ func NewReader(status ReaderStatus, nfc *iso7816.NfcSession, cscaCertPool cms.Ce
 }
 
 func (reader *Reader) SkipPace() {
+	reader.mu.Lock()
+	defer reader.mu.Unlock()
 	reader.skipPace = true
 }
 
 func (reader *Reader) SkipImages() {
+	reader.mu.Lock()
+	defer reader.mu.Unlock()
 	reader.skipImages = true
 }
 
@@ -115,6 +130,8 @@ func (reader *Reader) WithAAChallenge(challenge []byte) (*Reader, error) {
 	if len(challenge) != 8 {
 		return nil, fmt.Errorf("[WithAAChallenge] challenge must be exactly 8 bytes, got %d", len(challenge))
 	}
+	reader.mu.Lock()
+	defer reader.mu.Unlock()
 	reader.aaChallenge = bytes.Clone(challenge)
 	return reader, nil
 }
@@ -141,6 +158,12 @@ func NewReaderState(atr []byte, ats []byte, password *password.Password) *Reader
 // - also performs doc.Verify() and Passive Authentication!
 // NB returns partial data (docEx, apduLog) in the event of an error
 func (reader *Reader) ReadDocument(password *password.Password, atr []byte, ats []byte) (docEx *document.DocumentEx, apduLog *iso7816.ApduLog, err error) {
+	// Locked for the whole call: Reader is single-use/single-session, and this
+	// also serialises accidental concurrent calls on a shared instance instead
+	// of racing on skipPace/skipImages/aaChallenge and corrupting the heap.
+	reader.mu.Lock()
+	defer reader.mu.Unlock()
+
 	defer func() {
 		if e := recover(); e != nil {
 			switch x := e.(type) {

--- a/reader/reader_test.go
+++ b/reader/reader_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/gmrtd/gmrtd/cms"
@@ -827,4 +828,30 @@ func TestRunStepsError(t *testing.T) {
 	if called != 2 {
 		t.Fatalf("expected 2 steps to run, got %d", called)
 	}
+}
+
+// Regression test for a heap-corruption crash observed under concurrent use:
+// a shared Reader's fields (skipPace/skipImages/aaChallenge) were written by
+// the configuration methods while ReadDocument read them from another
+// goroutine, unsynchronised. Run with `go test -race` to confirm the mutex
+// added to Reader closes the race - without it, this reliably trips the race
+// detector (and, in production, can corrupt the Go heap).
+func TestReaderConcurrentAccess(t *testing.T) {
+	var status MockStatus
+	var nfc *iso7816.NfcSession = iso7816.NewNfcSession(&iso7816.StaticTransceiver{RApdu: utils.HexToBytes("6A82")}) // 6A82: file not found
+	var reader *Reader = NewReader(&status, nfc, EmptyCscaTrustStore(t))
+	var pass *password.Password = password.NewPasswordNil()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			reader.SkipPace()
+			reader.SkipImages()
+			_, _ = reader.WithAAChallenge(make([]byte, 8))
+			_, _, _ = reader.ReadDocument(pass, nil, nil) // expected to fail fast (file not found)
+		}()
+	}
+	wg.Wait()
 }

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -6,6 +6,7 @@ package verifier
 import (
 	"bytes"
 	"fmt"
+	"sync"
 
 	"github.com/gmrtd/gmrtd/activeauth"
 	"github.com/gmrtd/gmrtd/chipauth"
@@ -15,7 +16,14 @@ import (
 	"github.com/gmrtd/gmrtd/passiveauth"
 )
 
+// Verifier is not safe for concurrent use: it is a single-use, single-goroutine
+// object for verifying one piece of evidence. mu guards aaChallenge (set via
+// WithAAChallenge) and serialises Verify, so a Verifier that is accidentally
+// shared and called from multiple goroutines fails safe (calls queue up)
+// rather than corrupting the Go heap.
 type Verifier struct {
+	mu sync.Mutex
+
 	cscaCertPool cms.CertPool
 	aaChallenge  []byte
 }
@@ -34,12 +42,18 @@ func (v *Verifier) WithAAChallenge(challenge []byte) (*Verifier, error) {
 	if len(challenge) != 8 {
 		return nil, fmt.Errorf("[WithAAChallenge] challenge must be exactly 8 bytes, got %d", len(challenge))
 	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
 	v.aaChallenge = bytes.Clone(challenge)
 	return v, nil
 }
 
 // TODO - need to think about hard errors for PA, and CA.. currently only have hard-error for AA nonce mismatch. Should we also hard-error if PA fails, or CA fails? Or just return the result in the DocumentEx.Session?
 func (v *Verifier) Verify(data []byte) (*document.DocumentEx, error) {
+	// Locked for the whole call: see the Verifier docstring above.
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
 	doc, caBundle, err := document.UnmarshalVerifiableDoc(data)
 	if err != nil {
 		return nil, fmt.Errorf("[Verify] UnmarshalVerifiableDoc error: %w", err)

--- a/verifier/verifier_test.go
+++ b/verifier/verifier_test.go
@@ -1,6 +1,7 @@
 package verifier
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/gmrtd/gmrtd/cms"
@@ -153,4 +154,26 @@ func TestVerifyNoAAChallenge(t *testing.T) {
 	if docEx.Session.ActiveAuthResult == nil || !docEx.Session.ActiveAuthResult.Success {
 		t.Errorf("expected successful AA result without challenge binding")
 	}
+}
+
+// Regression test for a heap-corruption crash observed under concurrent use:
+// a shared Verifier's aaChallenge field was written by WithAAChallenge while
+// Verify read it from another goroutine, unsynchronised. Run with
+// `go test -race` to confirm the mutex added to Verifier closes the race -
+// without it, this reliably trips the race detector (and, in production, can
+// corrupt the Go heap).
+func TestVerifierConcurrentAccess(t *testing.T) {
+	v := emptyVerifier()
+	data := buildVerifiableDocWithAA(t, testAANonce, testAASig)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = v.WithAAChallenge(make([]byte, 8))
+			_, _ = v.Verify(data)
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
Fixed #433 