### PR TITLE
fix(cms): tolerant DS certificate selection for issuerAndSerial SODs …

### DIFF
--- a/cms/cms.go
+++ b/cms/cms.go
@@ -29,6 +29,7 @@ import (
 	"slices"
 	"strings"
 	"time"
+	"unicode/utf16"
 
 	"github.com/gmrtd/gmrtd/cryptoutils"
 	"github.com/gmrtd/gmrtd/oid"
@@ -619,7 +620,7 @@ func (rdnSeq RDNSequence) Equal(other RDNSequence) bool {
 			if matched[j] {
 				continue
 			}
-			if aa.Type.Equal(ba.Type) && bytes.Equal(aa.Values.FullBytes, ba.Values.FullBytes) {
+			if aa.Type.Equal(ba.Type) && attributeValuesEqual(aa.Values, ba.Values) {
 				matched[j] = true
 				found = true
 				break
@@ -630,6 +631,59 @@ func (rdnSeq RDNSequence) Equal(other RDNSequence) bool {
 		}
 	}
 	return true
+}
+
+// attributeValuesEqual compares two RDN AttributeValues. It first tries an exact
+// byte match (the common case), then falls back to a normalized string comparison
+// so that the same Distinguished Name still matches when the SignerInfo issuer and
+// the embedded certificate issuer encode a value with a different DER string type
+// (e.g. PrintableString vs UTF8String), letter case, or insignificant whitespace.
+func attributeValuesEqual(a, b asn1.RawValue) bool {
+	if bytes.Equal(a.FullBytes, b.FullBytes) {
+		return true
+	}
+
+	na, okA := normalizedDirectoryString(a)
+	nb, okB := normalizedDirectoryString(b)
+	return okA && okB && na == nb
+}
+
+// normalizedDirectoryString decodes a DirectoryString-style AttributeValue and
+// applies the RFC 5280 §7.1 / RFC 4518 comparison rules used for Name matching:
+// case-fold, and treat leading, trailing and repeated inner whitespace as
+// insignificant. The bool is false when the value is not a recognized string
+// type, in which case the caller falls back to a raw byte comparison.
+func normalizedDirectoryString(v asn1.RawValue) (string, bool) {
+	if v.Class != asn1.ClassUniversal {
+		return "", false
+	}
+
+	var s string
+	switch v.Tag {
+	case asn1.TagUTF8String, asn1.TagPrintableString, asn1.TagIA5String, asn1.TagT61String, asn1.TagGeneralString:
+		// 8-bit string types: the content octets are the (ASCII/UTF-8/Latin-1) text.
+		s = string(v.Bytes)
+	case asn1.TagBMPString:
+		s = decodeBMPString(v.Bytes)
+	default:
+		return "", false
+	}
+
+	// caseIgnoreMatch + insignificant whitespace: strings.Fields trims and
+	// collapses any run of whitespace, then we case-fold the result.
+	return strings.ToLower(strings.Join(strings.Fields(s), " ")), true
+}
+
+// decodeBMPString decodes a BMPString (UTF-16BE) into a Go string.
+func decodeBMPString(b []byte) string {
+	if len(b)%2 != 0 {
+		return string(b)
+	}
+	u16 := make([]uint16, len(b)/2)
+	for i := range u16 {
+		u16[i] = uint16(b[2*i])<<8 | uint16(b[2*i+1])
+	}
+	return string(utf16.Decode(u16))
 }
 
 // Flatten returns all attributes across all RDN SETs as a single slice.
@@ -1003,6 +1057,19 @@ func (si *SignerInfo) selectCertificate(sd *SignedData) (*Certificate, error) {
 		return nil, fmt.Errorf("[selectCertificate] CertPool.Add error: %w", err)
 	}
 
+	// Diagnostics: surface exactly which certificates are embedded in the SOD.
+	// When selection fails (got:0) this is the only way to distinguish "DS cert
+	// absent" from "DS cert present but issuer/serial mismatch" from logs alone.
+	slog.Debug("selectCertificate - embedded certificates in SignedData", "cnt", sdCerts.Count())
+	for i := range sdCerts.certificates {
+		c := &sdCerts.certificates[i]
+		issuer := "<unparsable>"
+		if rdn, e := c.TbsCertificate.IssuerRDN(); e == nil {
+			issuer = rdn.String()
+		}
+		slog.Debug("selectCertificate - embedded cert", "idx", i, "serial", c.TbsCertificate.SerialNumber, "issuer", issuer)
+	}
+
 	var tmpCerts []Certificate
 
 	switch {
@@ -1020,6 +1087,20 @@ func (si *SignerInfo) selectCertificate(sd *SignedData) (*Certificate, error) {
 	}
 
 	if len(tmpCerts) != 1 {
+		// Fallback: the SignerIdentifier did not select exactly one embedded
+		// certificate. When the SOD embeds exactly one certificate we use it
+		// regardless of the SID, matching the reference implementation (JMRTD,
+		// which never selects by SID) and gmrtd's own pre-#353 behaviour. This
+		// is safe: the DS-cert's public key must still verify the SignedData
+		// signature, and the DS-cert must still chain to a trusted CSCA - both
+		// enforced downstream in SignerInfo.VerifyWithConfig - so a wrong cert
+		// cannot pass. It rescues passports (e.g. Ukraine) whose SID issuer is
+		// encoded differently from the embedded DS-cert issuer.
+		if sdCerts.Count() == 1 {
+			slog.Warn("[selectCertificate] SignerIdentifier did not match; using the sole embedded certificate (JMRTD-style fallback)",
+				"sid", utils.BytesToHex(si.Sid.FullBytes))
+			return &sdCerts.certificates[0], nil
+		}
 		return nil, fmt.Errorf("[selectCertificate] Expected a single matching Cert from within the SignedData (got:%d) (sid:%x)", len(tmpCerts), si.Sid.FullBytes)
 	}
 

--- a/cms/cms_coverage_test.go
+++ b/cms/cms_coverage_test.go
@@ -33,7 +33,7 @@ type lcExt struct {
 }
 
 type lcTBS struct {
-	Version    int          `asn1:"explicit,optional,tag:0"`
+	Version    int `asn1:"explicit,optional,tag:0"`
 	Serial     *big.Int
 	SigAlg     lcAlgID
 	Issuer     asn1.RawValue
@@ -80,13 +80,13 @@ func buildTestCertDER(t *testing.T, skiBytes []byte, extraExtensions []lcExt, va
 
 	cert := lcCert{
 		TBS: lcTBS{
-			Version: 2,
-			Serial:  big.NewInt(42),
-			SigAlg:  lcAlgID{Algorithm: oid.OidEcdsaWithSHA256},
-			Issuer:  asn1.RawValue{Tag: asn1.TagSequence, Class: asn1.ClassUniversal},
-			Validity: v,
-			Subject: asn1.RawValue{Tag: asn1.TagSequence, Class: asn1.ClassUniversal},
-			SPKI:    asn1.RawValue{Tag: asn1.TagSequence, Class: asn1.ClassUniversal},
+			Version:    2,
+			Serial:     big.NewInt(42),
+			SigAlg:     lcAlgID{Algorithm: oid.OidEcdsaWithSHA256},
+			Issuer:     asn1.RawValue{Tag: asn1.TagSequence, Class: asn1.ClassUniversal},
+			Validity:   v,
+			Subject:    asn1.RawValue{Tag: asn1.TagSequence, Class: asn1.ClassUniversal},
+			SPKI:       asn1.RawValue{Tag: asn1.TagSequence, Class: asn1.ClassUniversal},
 			Extensions: exts,
 		},
 		SigAlg: lcAlgID{Algorithm: oid.OidEcdsaWithSHA256},
@@ -161,7 +161,7 @@ func TestTBSCertificateSubjectRDN(t *testing.T) {
 // prepareVerificationData tests.
 func buildSimpleSI(attrs AttributeList) *SignerInfo {
 	return &SignerInfo{
-		DigestAlgorithm: AlgorithmIdentifier{Algorithm: oid.OidHashAlgorithmSHA256},
+		DigestAlgorithm:         AlgorithmIdentifier{Algorithm: oid.OidHashAlgorithmSHA256},
 		AuthenticatedAttributes: attrs,
 	}
 }
@@ -861,8 +861,8 @@ func TestCertVerifyParentUnrecognizedCritExt(t *testing.T) {
 	for j := range parents {
 		parents[j].TbsCertificate.Extensions = append(parents[j].TbsCertificate.Extensions,
 			Extension{
-				ObjectId: fakeOid,
-				Critical: true,
+				ObjectId:  fakeOid,
+				Critical:  true,
 				ExtnValue: asn1.RawValue{Bytes: []byte{0x05, 0x00}},
 			},
 		)
@@ -1037,6 +1037,74 @@ func TestCertVerifyParentExpired(t *testing.T) {
 		t.Fatal("expected no-valid-CA error when all parents are expired")
 	}
 	if !strings.Contains(err.Error(), "no valid CA parent found") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// selectCertificate - JMRTD-style fallback (issue #440)
+// ---------------------------------------------------------------------------
+
+// When the SignerIdentifier matches no embedded certificate but the SOD embeds
+// exactly one certificate, selectCertificate falls back to that sole cert
+// (matching JMRTD, which never selects by SID). Trust is still gated downstream
+// by the signature and CSCA-chain checks.
+func TestSelectCertificateFallbackSingleEmbeddedCert(t *testing.T) {
+	t.Parallel()
+
+	certDER := buildTestCertDER(t, testSKIBytes, nil, nil)
+	sd := &SignedData{Certificates: asn1.RawValue{Bytes: certDER}}
+
+	// SKI-based SID whose bytes match no embedded cert.
+	si := SignerInfo{Sid: asn1.RawValue{Tag: 0, Class: asn1.ClassContextSpecific, Bytes: []byte{0xde, 0xad, 0xbe, 0xef}}}
+
+	cert, err := si.selectCertificate(sd)
+	if err != nil {
+		t.Fatalf("expected fallback to succeed, got error: %v", err)
+	}
+	if cert == nil {
+		t.Fatal("expected the sole embedded cert, got nil")
+	}
+	if cert.TbsCertificate.SerialNumber.Cmp(big.NewInt(42)) != 0 {
+		t.Errorf("unexpected cert selected (serial %v)", cert.TbsCertificate.SerialNumber)
+	}
+}
+
+// When the SID matches nothing and MORE than one certificate is embedded, the
+// choice is ambiguous, so selectCertificate must NOT fall back - it errors.
+func TestSelectCertificateNoFallbackMultipleEmbeddedCerts(t *testing.T) {
+	t.Parallel()
+
+	cert1 := buildTestCertDER(t, testSKIBytes, nil, nil)
+	ski2 := []byte{0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32, 0x33, 0x34}
+	cert2 := buildTestCertDER(t, ski2, nil, nil)
+
+	both := append(append([]byte{}, cert1...), cert2...)
+	sd := &SignedData{Certificates: asn1.RawValue{Bytes: both}}
+
+	si := SignerInfo{Sid: asn1.RawValue{Tag: 0, Class: asn1.ClassContextSpecific, Bytes: []byte{0xde, 0xad, 0xbe, 0xef}}}
+
+	_, err := si.selectCertificate(sd)
+	if err == nil {
+		t.Fatal("expected error when SID matches nothing and multiple certs are embedded")
+	}
+	if !strings.Contains(err.Error(), "got:") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// With no embedded certificates at all there is nothing to fall back to.
+func TestSelectCertificateNoFallbackWhenNoCerts(t *testing.T) {
+	t.Parallel()
+
+	sd := &SignedData{}
+	si := SignerInfo{Sid: asn1.RawValue{Tag: 0, Class: asn1.ClassContextSpecific, Bytes: []byte{0xde, 0xad, 0xbe, 0xef}}}
+
+	_, err := si.selectCertificate(sd)
+	if err == nil {
+		t.Fatal("expected error when no certs are embedded")
+	}
+	if !strings.Contains(err.Error(), "got:0") {
 		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/cms/rdn_sid_test.go
+++ b/cms/rdn_sid_test.go
@@ -126,6 +126,106 @@ func TestRDNSequenceEqualMultiValuedSET(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// RDNSequence.Equal - normalized string matching (issue #440)
+//
+// The SignerInfo issuer copy and the embedded DS certificate issuer can encode
+// the same Distinguished Name with a different DER string type, letter case, or
+// insignificant whitespace. These must still compare equal so the DS cert can be
+// selected from the SOD.
+// ---------------------------------------------------------------------------
+
+const (
+	tagUTF8String      = 12
+	tagPrintableString = 19
+	tagBMPString       = 30
+)
+
+// makeAttrTagged builds an Attribute whose value uses an explicit universal
+// string tag (short-form length; sufficient for test values).
+func makeAttrTagged(oidVal asn1.ObjectIdentifier, tag int, content []byte) Attribute {
+	full := append([]byte{byte(tag), byte(len(content))}, content...)
+	return Attribute{
+		Type:   oidVal,
+		Values: asn1.RawValue{Class: asn1.ClassUniversal, Tag: tag, Bytes: content, FullBytes: full},
+	}
+}
+
+func bmpBytes(s string) []byte {
+	out := make([]byte, 0, len(s)*2)
+	for _, r := range s {
+		out = append(out, byte(r>>8), byte(r&0xff))
+	}
+	return out
+}
+
+func TestRDNSequenceEqualDifferentStringEncoding(t *testing.T) {
+	t.Parallel()
+	// Same DN, but one side is PrintableString and the other UTF8String.
+	a := RDNSequence{
+		RelativeDistinguishedNameSET{makeAttrTagged(oid.OidCommonName, tagPrintableString, []byte("CSCA-UKRAINE"))},
+	}
+	b := RDNSequence{
+		RelativeDistinguishedNameSET{makeAttrTagged(oid.OidCommonName, tagUTF8String, []byte("CSCA-UKRAINE"))},
+	}
+	if !a.Equal(b) {
+		t.Fatal("same DN with PrintableString vs UTF8String encoding should be equal")
+	}
+}
+
+func TestRDNSequenceEqualCaseInsensitive(t *testing.T) {
+	t.Parallel()
+	a := RDNSequence{
+		RelativeDistinguishedNameSET{makeAttrTagged(oid.OidOrganizationName, tagPrintableString, []byte("bund"))},
+	}
+	b := RDNSequence{
+		RelativeDistinguishedNameSET{makeAttrTagged(oid.OidOrganizationName, tagUTF8String, []byte("BUND"))},
+	}
+	if !a.Equal(b) {
+		t.Fatal("DN differing only in letter case should be equal")
+	}
+}
+
+func TestRDNSequenceEqualWhitespaceInsensitive(t *testing.T) {
+	t.Parallel()
+	a := RDNSequence{
+		RelativeDistinguishedNameSET{makeAttrTagged(oid.OidCommonName, tagPrintableString, []byte("Malaysia  Country Signer"))},
+	}
+	b := RDNSequence{
+		RelativeDistinguishedNameSET{makeAttrTagged(oid.OidCommonName, tagPrintableString, []byte(" Malaysia Country Signer "))},
+	}
+	if !a.Equal(b) {
+		t.Fatal("DN differing only in insignificant whitespace should be equal")
+	}
+}
+
+func TestRDNSequenceEqualBMPString(t *testing.T) {
+	t.Parallel()
+	a := RDNSequence{
+		RelativeDistinguishedNameSET{makeAttrTagged(oid.OidCommonName, tagBMPString, bmpBytes("CSCA-UKRAINE"))},
+	}
+	b := RDNSequence{
+		RelativeDistinguishedNameSET{makeAttrTagged(oid.OidCommonName, tagUTF8String, []byte("CSCA-UKRAINE"))},
+	}
+	if !a.Equal(b) {
+		t.Fatal("same DN encoded as BMPString vs UTF8String should be equal")
+	}
+}
+
+func TestRDNSequenceEqualDifferentValueStillUnequal(t *testing.T) {
+	t.Parallel()
+	// Guard: normalization must not collapse genuinely different values.
+	a := RDNSequence{
+		RelativeDistinguishedNameSET{makeAttrTagged(oid.OidCommonName, tagPrintableString, []byte("CSCA-UKRAINE"))},
+	}
+	b := RDNSequence{
+		RelativeDistinguishedNameSET{makeAttrTagged(oid.OidCommonName, tagUTF8String, []byte("CSCA-GERMANY"))},
+	}
+	if a.Equal(b) {
+		t.Fatal("different common names must not be equal despite encoding normalization")
+	}
+}
+
+// ---------------------------------------------------------------------------
 // RDNSequence.Flatten
 // ---------------------------------------------------------------------------
 
@@ -284,7 +384,11 @@ func TestSelectCertificateUnsupportedSIDTag(t *testing.T) {
 // selectCertificate – IssuerAndSerialNumber SID with no matching cert
 // ---------------------------------------------------------------------------
 
-func TestSelectCertificateIssuerSerialNoMatch(t *testing.T) {
+// When the IssuerAndSerialNumber SID matches no embedded cert but the SOD embeds
+// exactly one certificate, selectCertificate falls back to that sole cert (issue
+// #440, JMRTD-style). Trust remains gated by the downstream signature and
+// CSCA-chain checks.
+func TestSelectCertificateIssuerSerialNoMatchFallsBackToSoleCert(t *testing.T) {
 	t.Parallel()
 
 	certBytes := utils.HexToBytes("308203df30820366a00302010202086189db18b6ede857300a06082a8648ce3d040303303f310b3009060355040613024154310b3009060355040a0c024756310c300a060355040b0c03424d493115301306035504030c0c435343412d41555354524941301e170d3233303133313038303430325a170d3333303530363038303430325a3054310b3009060355040613024154310b3009060355040a0c024756310c300a060355040b0c03424d49310f300d060355040513063030343031353119301706035504030c1044532d415553545249412d654d525444308201333081ec06072a8648ce3d02013081e0020101302c06072a8648ce3d0101022100a9fb57dba1eea9bc3e660a909d838d726e3bf623d52620282013481d1f6e5377304404207d5a0975fc2c3057eef67530417affe7fb8055c126dc5c6ce94a4b44f330b5d9042026dc5c6ce94a4b44f330b5d9bbd77cbf958416295cf7e1ce6bccdc18ff8c07b60441048bd2aeb9cb7e57cb2c4b482ffc81b7afb9de27e1e3bd23c23a4453bd9ace3262547ef835c3dac4fd97f8461a14611dc9c27745132ded8e545c1d54c72f046997022100a9fb57dba1eea9bc3e660a909d838d718c397aa3b561a6f7901e0e82974856a7020101034200048893905193f315ee2e2f1eee3fd5a496f6637deb3778cfe7cc2f6c7f0682acc795b0290265a2cb83119343544f2bbfe42974159ac77b113dafbee860c2523c06a382015930820155301d0603551d0e04160414e76eaa567acf6568c660c985717c3c8a50bd024b301f0603551d230418301680142692c7e398abfbe35192d3f26e9a317d1fed53bd301a0603551d1004133011810f32303233303530363038303430325a30160603551d20040f300d300b06092a28000a0102010101303e0603551d1f043730353033a031a02f862d687474703a2f2f7777772e626d692e67762e61742f637363612f63726c2f43534341415553545249412e63726c300e0603551d0f0101ff04040302078030370603551d120430302ea410300e310c300a06035504070c03415554861a687474703a2f2f7777772e626d692e67762e61742f637363612f30370603551d110430302ea410300e310c300a06035504070c03415554861a687474703a2f2f7777772e626d692e67762e61742f637363612f301d06076781080101060204123010020100310b1301501302415213024944300a06082a8648ce3d040303036700306402303af7ae31ca6b8fafca6ec51985997f7119fb2e6d20d61b5327d5740109aa310b410bfb44f354e086f207fcab721e69ae023046c68fb7909f994350a2d1c84d1ae5dff8c00de6d86b7891a6cf90ceea09159402e6e2ed3fa548db28d33146319eefda")
@@ -309,11 +413,16 @@ func TestSelectCertificateIssuerSerialNoMatch(t *testing.T) {
 
 	si := &sd.SignerInfos[0]
 	cert, err := si.selectCertificate(sd)
-	if err == nil {
-		t.Fatal("expected error when no cert matches IssuerAndSerialNumber")
+	if err != nil {
+		t.Fatalf("expected fallback to the sole embedded cert, got error: %v", err)
 	}
-	if cert != nil {
-		t.Fatal("cert should be nil on error")
+	if cert == nil {
+		t.Fatal("expected the sole embedded cert, got nil")
+	}
+	// AT DS cert serial 0x6189db18b6ede857
+	expSerial, _ := new(big.Int).SetString("6189db18b6ede857", 16)
+	if cert.TbsCertificate.SerialNumber.Cmp(expSerial) != 0 {
+		t.Errorf("unexpected cert selected (serial %x)", cert.TbsCertificate.SerialNumber)
 	}
 }
 


### PR DESCRIPTION
…(#440)

Passive Authentication failed for Ukrainian passports because selectCertificate could not locate the embedded DS certificate referenced by an issuerAndSerialNumber SignerIdentifier (got:0).

Two changes:

1. RDNSequence.Equal now normalizes attribute values (DER string type, case, insignificant whitespace per RFC 5280 §7.1 / RFC 4518) instead of only tolerating attribute reordering, so the same issuer DN matches across PrintableString/UTF8String/BMPString encodings.

2. selectCertificate falls back to the sole embedded certificate when the SID matches nothing but exactly one cert is embedded. This mirrors the reference implementation (JMRTD's getDocSigningCertificate, which never selects by SID) and gmrtd's own pre-#353 behaviour. It is safe because trust is still gated downstream by the SignedData signature check and the DS->CSCA chain verification in SignerInfo.VerifyWithConfig.

Also logs the count and issuer/serial of embedded certs to distinguish "DS cert absent" from "DS cert present but SID mismatch".