### PR TITLE
fix(reader): fail closed on PACE error unless BAC fallback opted in

### DIFF
--- a/cmd/gmrtd-reader/main.go
+++ b/cmd/gmrtd-reader/main.go
@@ -49,7 +49,7 @@ func (pcscStatus *PCSCReaderStatus) Status(status reader.Status) {
 	slog.Info("Status", "status", status.String())
 }
 
-func cmdParams(args []string) (pass *password.Password, debug bool, apduMaxRead uint, skipPace bool, skipImages bool, sampleDoc bool, err error) {
+func cmdParams(args []string) (pass *password.Password, debug bool, apduMaxRead uint, skipPace bool, skipImages bool, allowBacFallbackOnPaceError bool, sampleDoc bool, err error) {
 	fs := flag.NewFlagSet("gmrtd-reader", flag.ContinueOnError)
 
 	documentNo := fs.String("doc", "", "Document Number")
@@ -60,34 +60,35 @@ func cmdParams(args []string) (pass *password.Password, debug bool, apduMaxRead 
 	maxRead := fs.Uint("maxRead", 0, "Maximum read amount (bytes) e.g. 1..65536")
 	skipPaceFlag := fs.Bool("skipPace", false, "Skip PACE")
 	skipImagesFlag := fs.Bool("skipImages", false, "Skip image data groups (DG2, DG7)")
+	allowBacFallbackOnPaceErrorFlag := fs.Bool("allowBacFallbackOnPaceError", false, "Allow BAC after a PACE error (default: fail closed)")
 	sampleDocFlag := fs.Bool("sampleDoc", false, "Generate the HTML report from static sample data instead of reading a card")
 
 	if err := fs.Parse(args); err != nil {
-		return nil, false, 0, false, false, false, err
+		return nil, false, 0, false, false, false, false, err
 	}
 
 	// sample-document mode bypasses card credentials entirely - no card is read
 	if *sampleDocFlag {
-		return nil, *debugFlag, *maxRead, *skipPaceFlag, *skipImagesFlag, true, nil
+		return nil, *debugFlag, *maxRead, *skipPaceFlag, *skipImagesFlag, *allowBacFallbackOnPaceErrorFlag, true, nil
 	}
 
 	if len(*documentNo) > 0 && len(*dateOfBirth) == 6 && len(*expiryDate) == 6 {
 		pass, err = password.NewPasswordMrzi(*documentNo, *dateOfBirth, *expiryDate)
 		if err != nil {
-			return nil, false, 0, false, false, false, err
+			return nil, false, 0, false, false, false, false, err
 		}
 	} else if len(*can) > 0 {
 		pass = password.NewPasswordCan(*can)
 	} else {
 		fs.PrintDefaults()
-		return nil, false, 0, false, false, false, fmt.Errorf("usage: must specify either doc+dob+exp *OR* can")
+		return nil, false, 0, false, false, false, false, fmt.Errorf("usage: must specify either doc+dob+exp *OR* can")
 	}
 
 	if *maxRead > 65536 {
-		return nil, false, 0, false, false, false, fmt.Errorf("maxRead must be 0 or between 1 and 65536")
+		return nil, false, 0, false, false, false, false, fmt.Errorf("maxRead must be 0 or between 1 and 65536")
 	}
 
-	return pass, *debugFlag, *maxRead, *skipPaceFlag, *skipImagesFlag, false, nil
+	return pass, *debugFlag, *maxRead, *skipPaceFlag, *skipImagesFlag, *allowBacFallbackOnPaceErrorFlag, false, nil
 }
 
 func initLogging(debug bool) {
@@ -164,7 +165,7 @@ type appDeps struct {
 	cscaMasterList       func() (cms.CertPool, error)
 	generateDocument     func(*document.DocumentEx, *iso7816.ApduLog) (*bytes.Buffer, error)
 	openBrowser          func(io.Reader) error
-	readDocumentFromCard func(pass *password.Password, maxRead uint, skipPace bool, skipImages bool, card smartCard, cscaCertPool cms.CertPool) (*document.DocumentEx, *iso7816.ApduLog, error)
+	readDocumentFromCard func(pass *password.Password, maxRead uint, skipPace bool, skipImages bool, allowBacFallbackOnPaceError bool, card smartCard, cscaCertPool cms.CertPool) (*document.DocumentEx, *iso7816.ApduLog, error)
 	sampleDocument       func(cscaCertPool cms.CertPool) (*document.DocumentEx, error)
 }
 
@@ -207,12 +208,13 @@ func runWithDeps(args []string, deps appDeps) error {
 	var maxRead uint = 0
 	var skipPace bool = false
 	var skipImages bool = false
+	var allowBacFallbackOnPaceError bool = false
 	var sampleDoc bool = false
 	var err error
 
 	fmt.Printf("GMRTD:v%s\n\n", version.Version)
 
-	pass, debug, maxRead, skipPace, skipImages, sampleDoc, err = cmdParams(args)
+	pass, debug, maxRead, skipPace, skipImages, allowBacFallbackOnPaceError, sampleDoc, err = cmdParams(args)
 	if err != nil {
 		return err
 	}
@@ -252,7 +254,7 @@ func runWithDeps(args []string, deps appDeps) error {
 			return err
 		}
 
-		documentEx, apduLog, err = deps.readDocumentFromCard(pass, maxRead, skipPace, skipImages, card, cscaCertPool)
+		documentEx, apduLog, err = deps.readDocumentFromCard(pass, maxRead, skipPace, skipImages, allowBacFallbackOnPaceError, card, cscaCertPool)
 		if err != nil {
 			slog.Error("readDocumentFromCard", "error", err)
 			return err
@@ -281,6 +283,7 @@ func readDocumentFromCard(
 	maxRead uint,
 	skipPace bool,
 	skipImages bool,
+	allowBacFallbackOnPaceError bool,
 	card smartCard,
 	cscaCertPool cms.CertPool,
 ) (*document.DocumentEx, *iso7816.ApduLog, error) {
@@ -309,6 +312,10 @@ func readDocumentFromCard(
 
 	if skipImages {
 		r.SkipImages()
+	}
+
+	if allowBacFallbackOnPaceError {
+		r.AllowBacFallbackOnPaceError()
 	}
 
 	return r.ReadDocument(pass, atr, ats)

--- a/cmd/gmrtd-reader/main_test.go
+++ b/cmd/gmrtd-reader/main_test.go
@@ -80,58 +80,73 @@ func TestCscaMasterList(t *testing.T) {
 
 func TestCmdParamsSuccess(t *testing.T) {
 	tests := []struct {
-		name             string
-		args             []string
-		wantDebug        bool
-		wantApduMaxRead  uint
-		wantSkipPace     bool
-		wantSkipImages   bool
+		name                           string
+		args                           []string
+		wantDebug                      bool
+		wantApduMaxRead                uint
+		wantSkipPace                   bool
+		wantSkipImages                 bool
+		wantAllowBacFallbackOnPaceError bool
 	}{
 		{
-			name:            "valid CAN only",
-			args:            []string{"-can", "123456"},
-			wantDebug:       false,
-			wantApduMaxRead: 0,
-			wantSkipPace:    false,
-			wantSkipImages:  false,
+			name:                            "valid CAN only",
+			args:                            []string{"-can", "123456"},
+			wantDebug:                       false,
+			wantApduMaxRead:                 0,
+			wantSkipPace:                    false,
+			wantSkipImages:                  false,
+			wantAllowBacFallbackOnPaceError: false,
 		},
 		{
-			name:            "valid CAN with flags",
-			args:            []string{"-can", "123456", "-debug", "-maxRead", "1024", "-skipPace"},
-			wantDebug:       true,
-			wantApduMaxRead: 1024,
-			wantSkipPace:    true,
-			wantSkipImages:  false,
+			name:                            "valid CAN with flags",
+			args:                            []string{"-can", "123456", "-debug", "-maxRead", "1024", "-skipPace"},
+			wantDebug:                       true,
+			wantApduMaxRead:                 1024,
+			wantSkipPace:                    true,
+			wantSkipImages:                  false,
+			wantAllowBacFallbackOnPaceError: false,
 		},
 		{
-			name:            "valid MRZ fields",
-			args:            []string{"-doc", "D23145890", "-dob", "740812", "-exp", "120415"},
-			wantDebug:       false,
-			wantApduMaxRead: 0,
-			wantSkipPace:    false,
-			wantSkipImages:  false,
+			name:                            "valid MRZ fields",
+			args:                            []string{"-doc", "D23145890", "-dob", "740812", "-exp", "120415"},
+			wantDebug:                       false,
+			wantApduMaxRead:                 0,
+			wantSkipPace:                    false,
+			wantSkipImages:                  false,
+			wantAllowBacFallbackOnPaceError: false,
 		},
 		{
-			name:            "valid MRZ fields with flags",
-			args:            []string{"-doc", "D23145890", "-dob", "740812", "-exp", "120415", "-debug", "-maxRead", "2048", "-skipPace"},
-			wantDebug:       true,
-			wantApduMaxRead: 2048,
-			wantSkipPace:    true,
-			wantSkipImages:  false,
+			name:                            "valid MRZ fields with flags",
+			args:                            []string{"-doc", "D23145890", "-dob", "740812", "-exp", "120415", "-debug", "-maxRead", "2048", "-skipPace"},
+			wantDebug:                       true,
+			wantApduMaxRead:                 2048,
+			wantSkipPace:                    true,
+			wantSkipImages:                  false,
+			wantAllowBacFallbackOnPaceError: false,
 		},
 		{
-			name:            "valid CAN with skipImages",
-			args:            []string{"-can", "123456", "-skipImages"},
-			wantDebug:       false,
-			wantApduMaxRead: 0,
-			wantSkipPace:    false,
-			wantSkipImages:  true,
+			name:                            "valid CAN with skipImages",
+			args:                            []string{"-can", "123456", "-skipImages"},
+			wantDebug:                       false,
+			wantApduMaxRead:                 0,
+			wantSkipPace:                    false,
+			wantSkipImages:                  true,
+			wantAllowBacFallbackOnPaceError: false,
+		},
+		{
+			name:                            "valid CAN with allowBacFallbackOnPaceError",
+			args:                            []string{"-can", "123456", "-allowBacFallbackOnPaceError"},
+			wantDebug:                       false,
+			wantApduMaxRead:                 0,
+			wantSkipPace:                    false,
+			wantSkipImages:                  false,
+			wantAllowBacFallbackOnPaceError: true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			pass, debug, apduMaxRead, skipPace, skipImages, sampleDoc, err := cmdParams(tc.args)
+			pass, debug, apduMaxRead, skipPace, skipImages, allowBacFallbackOnPaceError, sampleDoc, err := cmdParams(tc.args)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -149,6 +164,9 @@ func TestCmdParamsSuccess(t *testing.T) {
 			}
 			if skipImages != tc.wantSkipImages {
 				t.Fatalf("skipImages = %v, want %v", skipImages, tc.wantSkipImages)
+			}
+			if allowBacFallbackOnPaceError != tc.wantAllowBacFallbackOnPaceError {
+				t.Fatalf("allowBacFallbackOnPaceError = %v, want %v", allowBacFallbackOnPaceError, tc.wantAllowBacFallbackOnPaceError)
 			}
 			if sampleDoc {
 				t.Fatalf("sampleDoc = true, want false")
@@ -207,7 +225,7 @@ func TestCmdParamsError(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			pass, debug, apduMaxRead, skipPace, _, _, err := cmdParams(tc.args)
+			pass, debug, apduMaxRead, skipPace, _, _, _, err := cmdParams(tc.args)
 			if err == nil {
 				t.Fatalf("expected error, got nil")
 			}
@@ -242,7 +260,7 @@ func TestCmdParamsSampleDoc(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			pass, _, _, _, _, sampleDoc, err := cmdParams(tc.args)
+			pass, _, _, _, _, _, sampleDoc, err := cmdParams(tc.args)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -469,6 +487,7 @@ func TestRunWithDepsReadDocumentFromCardError(t *testing.T) {
 		maxRead uint,
 		skipPace bool,
 		skipImages bool,
+		allowBacFallbackOnPaceError bool,
 		card smartCard,
 		cscaCertPool cms.CertPool,
 	) (*document.DocumentEx, *iso7816.ApduLog, error) {
@@ -500,6 +519,7 @@ func TestRunWithDepsGenerateDocumentError(t *testing.T) {
 		maxRead uint,
 		skipPace bool,
 		skipImages bool,
+		allowBacFallbackOnPaceError bool,
 		card smartCard,
 		cscaCertPool cms.CertPool,
 	) (*document.DocumentEx, *iso7816.ApduLog, error) {
@@ -534,6 +554,7 @@ func TestRunWithDepsOpenBrowserError(t *testing.T) {
 		maxRead uint,
 		skipPace bool,
 		skipImages bool,
+		allowBacFallbackOnPaceError bool,
 		card smartCard,
 		cscaCertPool cms.CertPool,
 	) (*document.DocumentEx, *iso7816.ApduLog, error) {
@@ -561,6 +582,7 @@ func TestReadDocumentFromCardReturnsReaderError(t *testing.T) {
 	_, _, err := readDocumentFromCard(
 		password.NewPasswordCan("123456"),
 		0,
+		false,
 		false,
 		false,
 		card,
@@ -592,6 +614,7 @@ func TestReadDocumentFromCardIgnoresAtrAtsErrors(t *testing.T) {
 		0,
 		false,
 		false,
+		false,
 		card,
 		&cms.GenericCertPool{},
 	)
@@ -621,6 +644,7 @@ func TestReadDocumentFromCardPropagatesReaderFailureFromApdu(t *testing.T) {
 		password.NewPasswordCan("123456"),
 		1000,
 		true,
+		false,
 		false,
 		card,
 		&cms.GenericCertPool{},

--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -141,21 +141,23 @@ func NewPasswordCan(can string) (*MrtdPassword, error) {
 
 // Reader is not safe for concurrent use: it is a single-use, single-goroutine
 // object for driving one document read. mu guards the mutable configuration
-// fields (set via SetApduMaxLe/SkipPace/SkipImages/WithAAChallenge) and
-// serialises ReadDocument, so a Reader that a host app accidentally shares
-// and calls from multiple threads (e.g. gomobile bindings invoked from
-// several Swift/Kotlin dispatch queues) fails safe - calls queue up - rather
-// than racing on these fields and corrupting the Go heap. Callers should
-// still construct a new Reader per read rather than relying on this lock.
+// fields (set via SetApduMaxLe/SkipPace/SkipImages/
+// AllowBacFallbackOnPaceError/WithAAChallenge) and serialises ReadDocument, so
+// a Reader that a host app accidentally shares and calls from multiple
+// threads (e.g. gomobile bindings invoked from several Swift/Kotlin dispatch
+// queues) fails safe - calls queue up - rather than racing on these fields
+// and corrupting the Go heap. Callers should still construct a new Reader per
+// read rather than relying on this lock.
 type Reader struct {
 	mu sync.Mutex
 
-	status      ReaderStatus
-	transceiver Transceiver
-	maxRead     int
-	skipPace    bool
-	skipImages  bool
-	aaChallenge []byte
+	status                      ReaderStatus
+	transceiver                 Transceiver
+	maxRead                     int
+	skipPace                    bool
+	skipImages                  bool
+	allowBacFallbackOnPaceError bool
+	aaChallenge                 []byte
 }
 
 type Document struct {
@@ -193,6 +195,14 @@ func (r *Reader) SkipImages() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.skipImages = true
+}
+
+// AllowBacFallbackOnPaceError configures the reader to continue to BAC when
+// PACE is attempted and fails. The default is fail-closed.
+func (r *Reader) AllowBacFallbackOnPaceError() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.allowBacFallbackOnPaceError = true
 }
 
 // WithAAChallenge sets a caller-supplied 8-byte RND.IFD challenge for Active
@@ -259,6 +269,10 @@ func (r *Reader) ReadDocument(password *MrtdPassword, atr []byte, ats []byte) (d
 
 	if r.skipImages {
 		gmrtdReader.SkipImages()
+	}
+
+	if r.allowBacFallbackOnPaceError {
+		gmrtdReader.AllowBacFallbackOnPaceError()
 	}
 
 	if r.aaChallenge != nil {

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -159,6 +159,20 @@ func TestSkipImages(t *testing.T) {
 	}
 }
 
+func TestAllowBacFallbackOnPaceError(t *testing.T) {
+	reader := &Reader{}
+
+	if reader.allowBacFallbackOnPaceError {
+		t.Fatalf("allowBacFallbackOnPaceError should default to false")
+	}
+
+	reader.AllowBacFallbackOnPaceError()
+
+	if !reader.allowBacFallbackOnPaceError {
+		t.Fatalf("allowBacFallbackOnPaceError should be true after calling AllowBacFallbackOnPaceError()")
+	}
+}
+
 func TestWithAAChallenge(t *testing.T) {
 	t.Run("valid 8 bytes", func(t *testing.T) {
 		r, err := (&Reader{}).WithAAChallenge(make([]byte, 8))
@@ -587,6 +601,7 @@ func TestReaderConcurrentAccess(t *testing.T) {
 			_ = reader.SetApduMaxLe(1000)
 			reader.SkipPace()
 			reader.SkipImages()
+			reader.AllowBacFallbackOnPaceError()
 			_, _ = reader.WithAAChallenge(make([]byte, 8))
 			_, _ = reader.ReadDocument(pass, nil, nil) // expected to fail fast (static transceiver)
 		}()

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -72,21 +72,22 @@ var dgToFileId = map[int]uint16{
 
 // Reader is not safe for concurrent use: it is a single-use, single-goroutine
 // object for driving one document read. The mu mutex guards the mutable
-// configuration fields below (set via SkipPace/SkipImages/WithAAChallenge)
-// and serialises ReadDocument, so a Reader that is accidentally shared and
-// called from multiple goroutines fails safe (calls queue up) rather than
-// corrupting the Go heap - see mobile.Reader for the same concern one layer
-// up, which is where callers are most likely to accidentally share an
-// instance across threads.
+// configuration fields below (set via SkipPace/SkipImages/
+// AllowBacFallbackOnPaceError/WithAAChallenge) and serialises ReadDocument, so
+// a Reader that is accidentally shared and called from multiple goroutines
+// fails safe (calls queue up) rather than corrupting the Go heap - see
+// mobile.Reader for the same concern one layer up, which is where callers are
+// most likely to accidentally share an instance across threads.
 type Reader struct {
 	mu sync.Mutex
 
-	status       ReaderStatus
-	nfc          *iso7816.NfcSession
-	cscaCertPool cms.CertPool
-	skipPace     bool // skip PACE
-	skipImages   bool // skip image DGs (DG2, DG7)
-	aaChallenge  []byte
+	status                      ReaderStatus
+	nfc                         *iso7816.NfcSession
+	cscaCertPool                cms.CertPool
+	skipPace                    bool // skip PACE
+	skipImages                  bool // skip image DGs (DG2, DG7)
+	allowBacFallbackOnPaceError bool // permit BAC after a recorded PACE error
+	aaChallenge                 []byte
 }
 
 func NewReader(status ReaderStatus, nfc *iso7816.NfcSession, cscaCertPool cms.CertPool) *Reader {
@@ -107,6 +108,15 @@ func (reader *Reader) SkipImages() {
 	reader.mu.Lock()
 	defer reader.mu.Unlock()
 	reader.skipImages = true
+}
+
+// AllowBacFallbackOnPaceError configures the reader to continue to BAC when
+// PACE is attempted and fails. The default is fail-closed: a PACE error stops
+// ReadDocument before BAC. Session.PaceErr is still recorded either way.
+func (reader *Reader) AllowBacFallbackOnPaceError() {
+	reader.mu.Lock()
+	defer reader.mu.Unlock()
+	reader.allowBacFallbackOnPaceError = true
 }
 
 // WithAAChallenge sets a caller-supplied 8-byte RND.IFD challenge for Active
@@ -372,9 +382,16 @@ func performPace(reader *Reader, state *ReaderState) error {
 		return nil
 	}
 	reader.reportPhase(STATUS_PHASE_ACCESS_CONTROL_PACE)
-	// NB errors are just recorded at this point
 	state.docEx.Session.PaceResult, state.docEx.Session.PaceCamResult, state.docEx.Session.PaceErr = pace.NewPace(reader.nfc, &state.docEx.Document, state.password).DoPACE()
-	return nil
+	if state.docEx.Session.PaceErr == nil {
+		return nil
+	}
+	// Default: fail closed so PACE-fail does not silently fall through to BAC.
+	// Opt in via AllowBacFallbackOnPaceError for interoperability cases.
+	if reader.allowBacFallbackOnPaceError {
+		return nil
+	}
+	return fmt.Errorf("[performPace] PACE failed: %w", state.docEx.Session.PaceErr)
 }
 
 func performBac(reader *Reader, state *ReaderState) error {

--- a/reader/reader_test.go
+++ b/reader/reader_test.go
@@ -557,12 +557,59 @@ func TestPerformPaceTransceiverError(t *testing.T) {
 	}
 
 	err = performPace(reader, state)
+	if err == nil {
+		t.Fatalf("expected PACE error to be returned (fail-closed default)")
+	}
+
+	if state.docEx.Session.PaceErr == nil {
+		t.Fatalf("Pace error expected")
+	}
+
+	if !errors.Is(err, state.docEx.Session.PaceErr) {
+		t.Fatalf("returned error should wrap PaceErr; got %v", err)
+	}
+
+	if state.docEx.Session.PaceResult == nil {
+		t.Fatalf("PaceResult expected")
+	}
+
+	if state.docEx.Session.PaceResult.Success {
+		t.Fatalf("PaceResult FAILURE expected")
+	}
+}
+
+func TestPerformPaceAllowsBacFallbackOnPaceError(t *testing.T) {
+	// Same transceiver failure as TestPerformPaceTransceiverError, but with
+	// AllowBacFallbackOnPaceError so the historical BAC-fallback path remains.
+
+	var err error
+
+	var status MockStatus
+	var nfc *iso7816.NfcSession = iso7816.NewNfcSession(&iso7816.StaticTransceiver{RApdu: utils.HexToBytes("6FFF")}) // 6FFF: card dead
+	var reader *Reader = NewReader(&status, nfc, EmptyCscaTrustStore(t))
+	reader.AllowBacFallbackOnPaceError()
+
+	var pass *password.Password
+	pass, err = password.NewPasswordMrzi("123456", "100101", "301225")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	var state *ReaderState = NewReaderState(nil, nil, pass)
+
+	var cardAccessBytes []byte = utils.HexToBytes("31143012060A04007F0007020204020402010202010D")
+	state.docEx.Document.Mf.CardAccess, err = document.NewCardAccess(cardAccessBytes)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	err = performPace(reader, state)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
 	if state.docEx.Session.PaceErr == nil {
-		t.Fatalf("Pace error expected")
+		t.Fatalf("Pace error expected to be recorded")
 	}
 
 	if state.docEx.Session.PaceResult == nil {

--- a/reader/status_test.go
+++ b/reader/status_test.go
@@ -141,7 +141,13 @@ func TestAccessControlStepsReportPhase(t *testing.T) {
 
 			state.docEx.Document.Mf.CardAccess = cardAccess
 
-			if err = tc.step(reader, state); err != nil {
+			err = tc.step(reader, state)
+			if tc.name == "performPace" {
+				// Default is fail-closed on PACE error; phase is still reported first.
+				if err == nil {
+					t.Fatalf("expected PACE error (fail-closed default)")
+				}
+			} else if err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}
 


### PR DESCRIPTION
### Summary
Move PACE-fail handling into the core `reader` module (as requested): after `DoPACE`, if `Session.PaceErr` is set and BAC fallback is not explicitly allowed, `performPace` returns the error so `ReadDocument` does not continue to BAC.

Default is fail-closed. Clients that need the historical interoperability path can opt in via `AllowBacFallbackOnPaceError()` (same configuration style as `SkipPace`), exposed on:
- library `reader.Reader`
- CLI `-allowBacFallbackOnPaceError`
- mobile `Reader.AllowBacFallbackOnPaceError()`

`Session.PaceErr` / `PaceResult` are still recorded either way. Documents without PACE (no CardAccess / `DoPACE` returns nil) are unchanged.

### Behaviour
- PACE succeeds → continue with PACE
- PACE fails and fallback disabled (default) → return the PACE error
- PACE fails and fallback explicitly enabled → attempt BAC

### Test plan
- [x] `go test ./reader/ ./cmd/gmrtd-reader/ ./mobile/`
- [x] `TestPerformPaceTransceiverError` — fail-closed default
- [x] `TestPerformPaceAllowsBacFallbackOnPaceError` — opt-in path
- [x] CLI flag parsing + mobile setter coverage

### Context
Retarget of this PR per maintainer review (16–17 Aug). Optional constructive improvement from academic eMRTD observability work; happy to adjust naming or defaults if preferred.