### PR TITLE
feat(reader)!: report read progress as a typed status

### DIFF
--- a/cmd/gmrtd-reader/main.go
+++ b/cmd/gmrtd-reader/main.go
@@ -45,8 +45,8 @@ type PCSCReaderStatus struct {
 
 var _ reader.ReaderStatus = (*PCSCReaderStatus)(nil)
 
-func (status *PCSCReaderStatus) Status(msg string) {
-	slog.Info("Status", "msg", msg)
+func (pcscStatus *PCSCReaderStatus) Status(status reader.Status) {
+	slog.Info("Status", "status", status.String())
 }
 
 func cmdParams(args []string) (pass *password.Password, debug bool, apduMaxRead uint, skipPace bool, skipImages bool, sampleDoc bool, err error) {

--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -45,24 +45,29 @@ type Transceiver interface {
 	Transceive(cla int, ins int, p1 int, p2 int, data []byte, le int, encodedData []byte) []byte
 }
 
-// bind doesn't like referencing reader.ReaderStatus
-// so we redefine the interface here
-//
+// NB notes for maintainers of this package, deliberately kept out of the doc
+// comment below so that gobind does not copy them into the generated Java and
+// Objective-C that host application developers read:
+//   - bind doesn't like referencing reader.ReaderStatus, so the interface is
+//     redefined here rather than reused.
+//   - the phase crosses the binding as a plain int rather than as
+//     reader.StatusPhase: gomobile only binds named types whose underlying type is
+//     an interface or a struct pointer, so a Go named integer type - and any
+//     constant declared with one - is silently dropped from the generated code.
+
+// ReaderStatus receives progress updates while a document is being read.
 // The phase is one of the STATUS_PHASE_* constants below and dataGroup is the
 // LDS1 data-group number (1..16), which is only set for
 // STATUS_PHASE_READING_DATA_GROUP and 0 for every other phase.
-//
-// NB the phase crosses the binding as a plain int rather than as reader.StatusPhase:
-// gomobile only binds named types whose underlying type is an interface or a struct
-// pointer, so a Go named integer type - and any constant declared with one - is
-// silently dropped from the generated Java and Objective-C.
 type ReaderStatus interface {
 	Status(phase int, dataGroup int)
 }
 
 // Phases of a document read, as passed to ReaderStatus.Status.
-// The values are those of reader.StatusPhase - see reader/status.go for what each
-// phase means, and mobile_test.go for the check that the two lists agree.
+// Each is defined as the corresponding reader.STATUS_PHASE_* value, so the two
+// lists cannot drift apart; see reader/status.go for what each phase means, and
+// TestStatusPhaseValues in mobile_test.go for the check that pins the numbers,
+// which are part of this package's contract with a host application.
 const (
 	STATUS_PHASE_CONNECTING              int = reader.STATUS_PHASE_CONNECTING
 	STATUS_PHASE_READING_CARD_ACCESS     int = reader.STATUS_PHASE_READING_CARD_ACCESS
@@ -87,7 +92,14 @@ type readerStatusAdapter struct {
 
 var _ reader.ReaderStatus = (*readerStatusAdapter)(nil)
 
+// NB the nil check is here as well as in the engine: the engine always has a
+// non-nil ReaderStatus on this path (this adapter), so a host that passed null to
+// NewReader would otherwise panic inside the adapter instead.
 func (adapter *readerStatusAdapter) Status(status reader.Status) {
+	if adapter.status == nil {
+		return
+	}
+
 	adapter.status.Status(int(status.Phase), status.DataGroup)
 }
 

--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -47,8 +47,48 @@ type Transceiver interface {
 
 // bind doesn't like referencing reader.ReaderStatus
 // so we redefine the interface here
+//
+// The phase is one of the STATUS_PHASE_* constants below and dataGroup is the
+// LDS1 data-group number (1..16), which is only set for
+// STATUS_PHASE_READING_DATA_GROUP and 0 for every other phase.
+//
+// NB the phase crosses the binding as a plain int rather than as reader.StatusPhase:
+// gomobile only binds named types whose underlying type is an interface or a struct
+// pointer, so a Go named integer type - and any constant declared with one - is
+// silently dropped from the generated Java and Objective-C.
 type ReaderStatus interface {
-	Status(msg string)
+	Status(phase int, dataGroup int)
+}
+
+// Phases of a document read, as passed to ReaderStatus.Status.
+// The values are those of reader.StatusPhase - see reader/status.go for what each
+// phase means, and mobile_test.go for the check that the two lists agree.
+const (
+	STATUS_PHASE_CONNECTING              int = reader.STATUS_PHASE_CONNECTING
+	STATUS_PHASE_READING_CARD_ACCESS     int = reader.STATUS_PHASE_READING_CARD_ACCESS
+	STATUS_PHASE_ACCESS_CONTROL_PACE     int = reader.STATUS_PHASE_ACCESS_CONTROL_PACE
+	STATUS_PHASE_ACCESS_CONTROL_BAC      int = reader.STATUS_PHASE_ACCESS_CONTROL_BAC
+	STATUS_PHASE_READING_DIR             int = reader.STATUS_PHASE_READING_DIR
+	STATUS_PHASE_READING_SECURITY_OBJECT int = reader.STATUS_PHASE_READING_SECURITY_OBJECT
+	STATUS_PHASE_READING_COMMON_DATA     int = reader.STATUS_PHASE_READING_COMMON_DATA
+	STATUS_PHASE_READING_DATA_GROUP      int = reader.STATUS_PHASE_READING_DATA_GROUP
+	STATUS_PHASE_ACTIVE_AUTHENTICATION   int = reader.STATUS_PHASE_ACTIVE_AUTHENTICATION
+	STATUS_PHASE_CHIP_AUTHENTICATION     int = reader.STATUS_PHASE_CHIP_AUTHENTICATION
+	STATUS_PHASE_VERIFYING_DOCUMENT      int = reader.STATUS_PHASE_VERIFYING_DOCUMENT
+	STATUS_PHASE_PASSIVE_AUTHENTICATION  int = reader.STATUS_PHASE_PASSIVE_AUTHENTICATION
+	STATUS_PHASE_FINISHED                int = reader.STATUS_PHASE_FINISHED
+)
+
+// readerStatusAdapter passes the engine's typed status to the bound ReaderStatus
+// as the two ints the binding can carry.
+type readerStatusAdapter struct {
+	status ReaderStatus
+}
+
+var _ reader.ReaderStatus = (*readerStatusAdapter)(nil)
+
+func (adapter *readerStatusAdapter) Status(status reader.Status) {
+	adapter.status.Status(int(status.Phase), status.DataGroup)
 }
 
 type MrtdPassword struct {
@@ -199,7 +239,7 @@ func (r *Reader) ReadDocument(password *MrtdPassword, atr []byte, ats []byte) (d
 	}
 
 	var gmrtdReader *reader.Reader
-	gmrtdReader = reader.NewReader(r.status, nfc, certPool)
+	gmrtdReader = reader.NewReader(&readerStatusAdapter{status: r.status}, nfc, certPool)
 
 	if r.skipPace {
 		gmrtdReader.SkipPace()

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -3,6 +3,7 @@ package mobile
 import (
 	"reflect"
 	"regexp"
+	"strings"
 	"sync"
 	"testing"
 
@@ -617,5 +618,24 @@ func TestVersion(t *testing.T) {
 
 	if !semverRegex.MatchString(version) {
 		t.Errorf("invalid version format: %s", version)
+	}
+}
+
+// a host application that passes null for the ReaderStatus must still get the real
+// error back, not the nil dereference from reporting the first phase
+func TestReadDocumentNilStatusReportsRealError(t *testing.T) {
+	rdr := NewReader(nil, &iso7816.StaticTransceiver{})
+
+	pass, err := NewPasswordCan("123456")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if _, err = rdr.ReadDocument(pass, nil, nil); err == nil {
+		t.Fatalf("expected error")
+	}
+
+	if strings.Contains(err.Error(), "nil pointer") {
+		t.Errorf("nil ReaderStatus masked the read error (act:%s)", err)
 	}
 }

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -1,12 +1,14 @@
 package mobile
 
 import (
+	"reflect"
 	"regexp"
 	"sync"
 	"testing"
 
 	"github.com/gmrtd/gmrtd/document"
 	"github.com/gmrtd/gmrtd/iso7816"
+	"github.com/gmrtd/gmrtd/reader"
 )
 
 func TestNewPasswordMrz(t *testing.T) {
@@ -186,10 +188,113 @@ func TestWithAAChallenge(t *testing.T) {
 	}
 }
 
+// testReaderStatus records the status updates a host application would receive
+// through the binding.
+// NB guarded by a mutex because TestReaderConcurrentAccess shares one instance.
 type testReaderStatus struct {
+	mu       sync.Mutex
+	statuses [][2]int
 }
 
-func (status *testReaderStatus) Status(_ string) {
+func (status *testReaderStatus) Status(phase int, dataGroup int) {
+	status.mu.Lock()
+	defer status.mu.Unlock()
+	status.statuses = append(status.statuses, [2]int{phase, dataGroup})
+}
+
+func (status *testReaderStatus) Recorded() [][2]int {
+	status.mu.Lock()
+	defer status.mu.Unlock()
+	return append([][2]int(nil), status.statuses...)
+}
+
+// the phase values are part of the binding's contract: a host application built
+// against an earlier release compares the ints it receives against these, so they
+// must not be renumbered
+func TestStatusPhaseValues(t *testing.T) {
+	exp := map[string]int{
+		"connecting":              1,
+		"reading card access":     2,
+		"access control (PACE)":   3,
+		"access control (BAC)":    4,
+		"reading EF.DIR":          5,
+		"reading security object": 6,
+		"reading common data":     7,
+		"reading data group":      8,
+		"active authentication":   9,
+		"chip authentication":     10,
+		"verifying document":      11,
+		"passive authentication":  12,
+		"finished":                13,
+	}
+
+	act := map[string]int{
+		"connecting":              STATUS_PHASE_CONNECTING,
+		"reading card access":     STATUS_PHASE_READING_CARD_ACCESS,
+		"access control (PACE)":   STATUS_PHASE_ACCESS_CONTROL_PACE,
+		"access control (BAC)":    STATUS_PHASE_ACCESS_CONTROL_BAC,
+		"reading EF.DIR":          STATUS_PHASE_READING_DIR,
+		"reading security object": STATUS_PHASE_READING_SECURITY_OBJECT,
+		"reading common data":     STATUS_PHASE_READING_COMMON_DATA,
+		"reading data group":      STATUS_PHASE_READING_DATA_GROUP,
+		"active authentication":   STATUS_PHASE_ACTIVE_AUTHENTICATION,
+		"chip authentication":     STATUS_PHASE_CHIP_AUTHENTICATION,
+		"verifying document":      STATUS_PHASE_VERIFYING_DOCUMENT,
+		"passive authentication":  STATUS_PHASE_PASSIVE_AUTHENTICATION,
+		"finished":                STATUS_PHASE_FINISHED,
+	}
+
+	if !reflect.DeepEqual(act, exp) {
+		t.Errorf("phase values differ to expected (act:%v) (exp:%v)", act, exp)
+	}
+}
+
+// the engine's typed status has to arrive at the host as the phase and, for a
+// data-group read, the data-group number
+func TestReaderStatusAdapter(t *testing.T) {
+	tests := []struct {
+		name   string
+		status reader.Status
+		exp    [2]int
+	}{
+		{"phase only", reader.Status{Phase: reader.STATUS_PHASE_CONNECTING}, [2]int{STATUS_PHASE_CONNECTING, 0}},
+		{"data group", reader.Status{Phase: reader.STATUS_PHASE_READING_DATA_GROUP, DataGroup: 7}, [2]int{STATUS_PHASE_READING_DATA_GROUP, 7}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			hostStatus := &testReaderStatus{}
+
+			(&readerStatusAdapter{status: hostStatus}).Status(tc.status)
+
+			exp := [][2]int{tc.exp}
+			if act := hostStatus.Recorded(); !reflect.DeepEqual(act, exp) {
+				t.Errorf("recorded statuses differ to expected (act:%v) (exp:%v)", act, exp)
+			}
+		})
+	}
+}
+
+// NB basic test that will fail quickly due to static transceiver, so only the
+// first phase of the read is reported
+func TestReadDocumentReportsStatus(t *testing.T) {
+	status := &testReaderStatus{}
+
+	rdr := NewReader(status, &iso7816.StaticTransceiver{})
+
+	pass, err := NewPasswordCan("123456")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if _, err = rdr.ReadDocument(pass, nil, nil); err == nil {
+		t.Fatalf("expected error")
+	}
+
+	exp := [][2]int{{STATUS_PHASE_CONNECTING, 0}}
+	if act := status.Recorded(); !reflect.DeepEqual(act, exp) {
+		t.Errorf("recorded statuses differ to expected (act:%v) (exp:%v)", act, exp)
+	}
 }
 
 // NB basic test that will fail quickly due to static transceiver
@@ -344,10 +449,10 @@ func TestReadDocumentNilPassword(t *testing.T) {
 
 func TestCountryName(t *testing.T) {
 	tests := []struct {
-		name        string
-		mrzAlpha3   string
-		wantName    string
-		wantErr     bool
+		name      string
+		mrzAlpha3 string
+		wantName  string
+		wantErr   bool
 	}{
 		{name: "standard alpha-3", mrzAlpha3: "GBR", wantName: "United Kingdom"},
 		{name: "standard alpha-3 lowercase", mrzAlpha3: "gbr", wantName: "United Kingdom"},

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -70,10 +70,6 @@ var dgToFileId = map[int]uint16{
 	16: MRTDFileIdDG16,
 }
 
-type ReaderStatus interface {
-	Status(msg string)
-}
-
 // Reader is not safe for concurrent use: it is a single-use, single-goroutine
 // object for driving one document read. The mu mutex guards the mutable
 // configuration fields below (set via SkipPace/SkipImages/WithAAChallenge)
@@ -200,7 +196,7 @@ func (reader *Reader) ReadDocument(password *password.Password, atr []byte, ats 
 		return state.docEx, reader.nfc.ApduLog(), fmt.Errorf("[ReadDocument] runSteps error: %w", err)
 	}
 
-	reader.status.Status("Finished!")
+	reader.reportPhase(STATUS_PHASE_FINISHED)
 	slog.Info("** ReadDocument FINISHED **", "VerifiedChipAuthStatus", state.docEx.Session.VerifiedChipAuthStatus())
 
 	return state.docEx, reader.nfc.ApduLog(), nil
@@ -237,6 +233,9 @@ func recordAtrAts(_ *Reader, state *ReaderState) (err error) {
 
 func selectMF(reader *Reader, _ *ReaderState) (err error) {
 	// NB spec recommends not to use, but iOS may pre-select the MRTD AID
+	// NB selecting the MF is the first exchange with the chip, so this is where
+	//    the read reports that it is connecting
+	reader.reportPhase(STATUS_PHASE_CONNECTING)
 	slog.Info("Selecting MF")
 	if err = reader.nfc.SelectMF(); err != nil {
 		return fmt.Errorf("[selectMF] nfc.SelectMF error: %w", err)
@@ -256,7 +255,7 @@ func selectMrtdApplication(reader *Reader, _ *ReaderState) (err error) {
 // reads EF.SOD
 func readEfSod(reader *Reader, state *ReaderState) (err error) {
 	slog.Info("Read EF.SOD")
-	reader.status.Status("Reading EF.SOD")
+	reader.reportPhase(STATUS_PHASE_READING_SECURITY_OBJECT)
 	sodData, err := reader.nfc.ReadFile(MRTDFileIdEFSOD)
 	if err != nil {
 		return fmt.Errorf("[readEfSod] ReadFile error: %w", err)
@@ -272,7 +271,7 @@ func readEfSod(reader *Reader, state *ReaderState) (err error) {
 // reads EF.COM
 func readEfCom(reader *Reader, state *ReaderState) (err error) {
 	slog.Info("Read EF.COM")
-	reader.status.Status("Reading EF.COM")
+	reader.reportPhase(STATUS_PHASE_READING_COMMON_DATA)
 	efComData, err := reader.nfc.ReadFile(MRTDFileIdEFCOM)
 	if err != nil {
 		return fmt.Errorf("[readEfCom] ReadFile error: %w", err)
@@ -292,7 +291,7 @@ func readEfDir(reader *Reader, state *ReaderState) (err error) {
 	//        - not a big deal as this file is not used for any processing
 	//		  - EF.DIR observed on NL passport
 	slog.Info("Read EF.DIR")
-	reader.status.Status("Reading EF.DIR")
+	reader.reportPhase(STATUS_PHASE_READING_DIR)
 	efDirData, err := reader.nfc.ReadFile(MRTDFileIdEFDIR)
 	if err != nil {
 		return fmt.Errorf("[readEfDir] Read EF.DIR error: %w", err)
@@ -308,7 +307,7 @@ func readEfDir(reader *Reader, state *ReaderState) (err error) {
 // reads EF.CardAccess
 func readEfCardAccess(reader *Reader, state *ReaderState) (err error) {
 	slog.Info("Read EF.CardAccess")
-	reader.status.Status("Reading EF.CardAccess")
+	reader.reportPhase(STATUS_PHASE_READING_CARD_ACCESS)
 	// may not be present (OR may be present but not have PACE info)
 	cardAccessData, err := reader.nfc.ReadFile(MRTDFileIdCardAccess)
 	if err != nil {
@@ -344,7 +343,7 @@ func readLDS1dgs(reader *Reader, state *ReaderState) (err error) {
 		}
 
 		slog.Info("Reading DG", "DG", dgHash.DataGroupNumber)
-		reader.status.Status(fmt.Sprintf("Reading DG%02d", dgHash.DataGroupNumber))
+		reader.reportDataGroup(dgHash.DataGroupNumber)
 
 		var dgBytes []byte
 
@@ -366,7 +365,7 @@ func performPace(reader *Reader, state *ReaderState) error {
 	if reader.skipPace {
 		return nil
 	}
-	reader.status.Status("PACE")
+	reader.reportPhase(STATUS_PHASE_ACCESS_CONTROL_PACE)
 	// NB errors are just recorded at this point
 	state.docEx.Session.PaceResult, state.docEx.Session.PaceCamResult, state.docEx.Session.PaceErr = pace.NewPace(reader.nfc, &state.docEx.Document, state.password).DoPACE()
 	return nil
@@ -377,7 +376,7 @@ func performBac(reader *Reader, state *ReaderState) error {
 	if reader.nfc.SM() != nil {
 		return nil
 	}
-	reader.status.Status("BAC")
+	reader.reportPhase(STATUS_PHASE_ACCESS_CONTROL_BAC)
 	// NB errors are just recorded at this point
 	state.docEx.Session.BacResult, state.docEx.Session.BacErr = bac.NewBAC(reader.nfc, &state.docEx.Document, state.password).DoBAC()
 	return nil
@@ -385,10 +384,11 @@ func performBac(reader *Reader, state *ReaderState) error {
 
 func performChipAuthentication(reader *Reader, state *ReaderState) error {
 	slog.Info("Chip Authentication (AA/CA)")
-	reader.status.Status("Chip Authentication (AA/CA)")
 
 	// note: AA has the strongest backend verification level, so always execute if available (even if PACE-CAM has completed)
 	{
+		reader.reportPhase(STATUS_PHASE_ACTIVE_AUTHENTICATION)
+
 		// attempt active-authentication (if supported)
 		// NB errors are just recorded at this point
 		aa := activeauth.NewActiveAuth(reader.nfc, &state.docEx.Document)
@@ -403,6 +403,8 @@ func performChipAuthentication(reader *Reader, state *ReaderState) error {
 
 	// CA has a lower backend verification level, so only perform if ChipAuth not already completed (e.g. via AA or PACE-CAM)
 	if !state.docEx.Session.ChipAuthProtocolCompleted() {
+		reader.reportPhase(STATUS_PHASE_CHIP_AUTHENTICATION)
+
 		// attempt chip-authentication (if supported)
 		// NB errors are just recorded at this point
 		state.docEx.Session.ChipAuthResult, state.docEx.Session.ChipAuthErr = chipauth.NewChipAuth(reader.nfc, &state.docEx.Document).DoChipAuth()
@@ -414,14 +416,14 @@ func performChipAuthentication(reader *Reader, state *ReaderState) error {
 func performPassiveAuthentication(reader *Reader, state *ReaderState) error {
 	// perform passive authentication
 	// NB errors are just recorded at this point
-	reader.status.Status("Passive Authentication")
+	reader.reportPhase(STATUS_PHASE_PASSIVE_AUTHENTICATION)
 	state.docEx.Session.PassiveAuthResult, state.docEx.Session.PassiveAuthErr = passiveauth.PassiveAuth(&state.docEx.Document, reader.cscaCertPool)
 	return nil
 }
 
 func verifyDocument(reader *Reader, state *ReaderState) error {
 	// NB errors are just recorded at this point - see Session.DocumentVerifyErr / DocumentSummary.DataTrusted
-	reader.status.Status("Verifying Document")
+	reader.reportPhase(STATUS_PHASE_VERIFYING_DOCUMENT)
 	state.docEx.Session.DocumentVerifyErr = state.docEx.Document.Verify()
 	if state.docEx.Session.DocumentVerifyErr != nil {
 		slog.Error("Document.Verify", "error", state.docEx.Session.DocumentVerifyErr)

--- a/reader/reader_test.go
+++ b/reader/reader_test.go
@@ -15,10 +15,23 @@ import (
 	"github.com/gmrtd/gmrtd/utils"
 )
 
-type MockStatus struct{}
+// MockStatus records the status updates it receives, so tests can assert on them.
+// NB guarded by a mutex because TestReaderConcurrentAccess shares one instance.
+type MockStatus struct {
+	mu       sync.Mutex
+	statuses []Status
+}
 
-func (s *MockStatus) Status(_ string) {
-	// NB do nothing
+func (s *MockStatus) Status(status Status) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.statuses = append(s.statuses, status)
+}
+
+func (s *MockStatus) Recorded() []Status {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]Status(nil), s.statuses...)
 }
 
 func EmptyCscaTrustStore(t *testing.T) cms.CertPool {

--- a/reader/status.go
+++ b/reader/status.go
@@ -10,6 +10,13 @@ import "fmt"
 // Phases the Dart machine owns rather than the engine (NFC availability, pending,
 // cancelling, cancelled, failed) are deliberately absent: the engine never reaches
 // them, and a read that fails reports the failure through the returned error.
+//
+// A phase says which step the read has entered, not that the step found anything to
+// do. STATUS_PHASE_ACTIVE_AUTHENTICATION and STATUS_PHASE_CHIP_AUTHENTICATION are
+// both reported before the engine knows whether the document supports either
+// protocol (DG15 and DG14 respectively), so they are reported even for a document
+// that supports neither. A host that needs to know what actually ran should read the
+// session results after the read rather than infer it from the phases.
 type StatusPhase int
 
 // intentionally use explicit values instead of iota, so the numbers stay stable
@@ -90,10 +97,22 @@ type ReaderStatus interface {
 
 // reportPhase emits a status update for a phase that carries no data-group.
 func (reader *Reader) reportPhase(phase StatusPhase) {
-	reader.status.Status(Status{Phase: phase})
+	reader.report(Status{Phase: phase})
 }
 
 // reportDataGroup emits a status update for the data-group currently being read.
 func (reader *Reader) reportDataGroup(dataGroup int) {
-	reader.status.Status(Status{Phase: STATUS_PHASE_READING_DATA_GROUP, DataGroup: dataGroup})
+	reader.report(Status{Phase: STATUS_PHASE_READING_DATA_GROUP, DataGroup: dataGroup})
+}
+
+// report passes a status update on, if a ReaderStatus was provided.
+// NB a nil ReaderStatus is tolerated because the first update is emitted by the very
+// first read step, so without this a caller that passes nil panics before the read
+// can report the error it actually failed on.
+func (reader *Reader) report(status Status) {
+	if reader.status == nil {
+		return
+	}
+
+	reader.status.Status(status)
 }

--- a/reader/status.go
+++ b/reader/status.go
@@ -1,0 +1,99 @@
+package reader
+
+import "fmt"
+
+// StatusPhase identifies the stage of a document read that a status update refers to.
+//
+// The phases mirror the states of the Dart reader state-machine in
+// privacybydesign/vcmrtd (lib/src/document_reader.dart), which is the reference for
+// the distinctions a host application needs in order to drive a progress interface.
+// Phases the Dart machine owns rather than the engine (NFC availability, pending,
+// cancelling, cancelled, failed) are deliberately absent: the engine never reaches
+// them, and a read that fails reports the failure through the returned error.
+type StatusPhase int
+
+// intentionally use explicit values instead of iota, so the numbers stay stable
+// for hosts that receive them across the mobile binding (see mobile.ReaderStatus)
+const (
+	STATUS_PHASE_CONNECTING              = 1  // first exchange with the chip (SELECT MF)
+	STATUS_PHASE_READING_CARD_ACCESS     = 2  // EF.CardAccess
+	STATUS_PHASE_ACCESS_CONTROL_PACE     = 3  // PACE
+	STATUS_PHASE_ACCESS_CONTROL_BAC      = 4  // BAC (only attempted if PACE did not establish secure messaging)
+	STATUS_PHASE_READING_DIR             = 5  // EF.DIR
+	STATUS_PHASE_READING_SECURITY_OBJECT = 6  // EF.SOD
+	STATUS_PHASE_READING_COMMON_DATA     = 7  // EF.COM
+	STATUS_PHASE_READING_DATA_GROUP      = 8  // an LDS1 data-group, identified by Status.DataGroup
+	STATUS_PHASE_ACTIVE_AUTHENTICATION   = 9  // AA
+	STATUS_PHASE_CHIP_AUTHENTICATION     = 10 // CA (only attempted if chip authentication has not already completed)
+	STATUS_PHASE_VERIFYING_DOCUMENT      = 11
+	STATUS_PHASE_PASSIVE_AUTHENTICATION  = 12
+	STATUS_PHASE_FINISHED                = 13 // the read completed
+)
+
+func (phase StatusPhase) String() string {
+	switch phase {
+	case STATUS_PHASE_CONNECTING:
+		return "Connecting"
+	case STATUS_PHASE_READING_CARD_ACCESS:
+		return "Reading EF.CardAccess"
+	case STATUS_PHASE_ACCESS_CONTROL_PACE:
+		return "PACE"
+	case STATUS_PHASE_ACCESS_CONTROL_BAC:
+		return "BAC"
+	case STATUS_PHASE_READING_DIR:
+		return "Reading EF.DIR"
+	case STATUS_PHASE_READING_SECURITY_OBJECT:
+		return "Reading EF.SOD"
+	case STATUS_PHASE_READING_COMMON_DATA:
+		return "Reading EF.COM"
+	case STATUS_PHASE_READING_DATA_GROUP:
+		return "Reading DG"
+	case STATUS_PHASE_ACTIVE_AUTHENTICATION:
+		return "Active Authentication"
+	case STATUS_PHASE_CHIP_AUTHENTICATION:
+		return "Chip Authentication"
+	case STATUS_PHASE_VERIFYING_DOCUMENT:
+		return "Verifying Document"
+	case STATUS_PHASE_PASSIVE_AUTHENTICATION:
+		return "Passive Authentication"
+	case STATUS_PHASE_FINISHED:
+		return "Finished"
+	}
+
+	return fmt.Sprintf("*UnsupportedValue* (phase:%d)", int(phase))
+}
+
+// Status is a single progress update emitted during a document read.
+type Status struct {
+	Phase StatusPhase
+
+	// DataGroup is the LDS1 data-group number (1..16) being read. It is only set
+	// for STATUS_PHASE_READING_DATA_GROUP, and 0 for every other phase.
+	DataGroup int
+}
+
+// String describes the status in English. It exists for logs and for the CLI -
+// a host application should switch on Phase (and DataGroup) instead, as this text
+// is not localised and not part of the contract.
+func (status Status) String() string {
+	if status.Phase == STATUS_PHASE_READING_DATA_GROUP {
+		return fmt.Sprintf("Reading DG%02d", status.DataGroup)
+	}
+
+	return status.Phase.String()
+}
+
+// ReaderStatus receives progress updates while a document is being read.
+type ReaderStatus interface {
+	Status(status Status)
+}
+
+// reportPhase emits a status update for a phase that carries no data-group.
+func (reader *Reader) reportPhase(phase StatusPhase) {
+	reader.status.Status(Status{Phase: phase})
+}
+
+// reportDataGroup emits a status update for the data-group currently being read.
+func (reader *Reader) reportDataGroup(dataGroup int) {
+	reader.status.Status(Status{Phase: STATUS_PHASE_READING_DATA_GROUP, DataGroup: dataGroup})
+}

--- a/reader/status_test.go
+++ b/reader/status_test.go
@@ -1,0 +1,328 @@
+package reader
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gmrtd/gmrtd/document"
+	"github.com/gmrtd/gmrtd/iso7816"
+	"github.com/gmrtd/gmrtd/password"
+	"github.com/gmrtd/gmrtd/utils"
+)
+
+func TestStatusPhaseString(t *testing.T) {
+	phases := []StatusPhase{
+		STATUS_PHASE_CONNECTING,
+		STATUS_PHASE_READING_CARD_ACCESS,
+		STATUS_PHASE_ACCESS_CONTROL_PACE,
+		STATUS_PHASE_ACCESS_CONTROL_BAC,
+		STATUS_PHASE_READING_DIR,
+		STATUS_PHASE_READING_SECURITY_OBJECT,
+		STATUS_PHASE_READING_COMMON_DATA,
+		STATUS_PHASE_READING_DATA_GROUP,
+		STATUS_PHASE_ACTIVE_AUTHENTICATION,
+		STATUS_PHASE_CHIP_AUTHENTICATION,
+		STATUS_PHASE_VERIFYING_DOCUMENT,
+		STATUS_PHASE_PASSIVE_AUTHENTICATION,
+		STATUS_PHASE_FINISHED,
+	}
+
+	for _, phase := range phases {
+		if strings.Contains(phase.String(), "*UnsupportedValue*") {
+			t.Errorf("phase %d has no description", int(phase))
+		}
+	}
+
+	// a value outside the set should be reported as such, not silently described
+	if !strings.Contains(StatusPhase(99).String(), "*UnsupportedValue*") {
+		t.Errorf("expected *UnsupportedValue* for phase 99 (act:%s)", StatusPhase(99).String())
+	}
+}
+
+func TestStatusString(t *testing.T) {
+	tests := []struct {
+		name   string
+		status Status
+		exp    string
+	}{
+		{"data-group", Status{Phase: STATUS_PHASE_READING_DATA_GROUP, DataGroup: 1}, "Reading DG01"},
+		{"data-group (2 digits)", Status{Phase: STATUS_PHASE_READING_DATA_GROUP, DataGroup: 14}, "Reading DG14"},
+		{"other phase", Status{Phase: STATUS_PHASE_READING_COMMON_DATA}, "Reading EF.COM"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if act := tc.status.String(); act != tc.exp {
+				t.Errorf("Status.String differs to expected (act:%s) (exp:%s)", act, tc.exp)
+			}
+		})
+	}
+}
+
+// verifies that each read step reports its own phase, and that no phase carries a
+// data-group number other than the data-group read itself
+func TestStepsReportPhase(t *testing.T) {
+	tests := []struct {
+		name string
+		step ReaderStep
+		exp  StatusPhase
+	}{
+		{"selectMF", selectMF, STATUS_PHASE_CONNECTING},
+		{"readEfCardAccess", readEfCardAccess, STATUS_PHASE_READING_CARD_ACCESS},
+		{"readEfDir", readEfDir, STATUS_PHASE_READING_DIR},
+		{"readEfSod", readEfSod, STATUS_PHASE_READING_SECURITY_OBJECT},
+		{"readEfCom", readEfCom, STATUS_PHASE_READING_COMMON_DATA},
+		{"performChipAuthentication", performChipAuthentication, STATUS_PHASE_ACTIVE_AUTHENTICATION},
+		{"verifyDocument", verifyDocument, STATUS_PHASE_VERIFYING_DOCUMENT},
+		{"performPassiveAuthentication", performPassiveAuthentication, STATUS_PHASE_PASSIVE_AUTHENTICATION},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var status MockStatus
+			// 6A82: file not found - every step above completes (or soft-fails) on it
+			var nfc *iso7816.NfcSession = iso7816.NewNfcSession(&iso7816.StaticTransceiver{RApdu: utils.HexToBytes("6A82")})
+			var reader *Reader = NewReader(&status, nfc, EmptyCscaTrustStore(t))
+			var state *ReaderState = NewReaderState(nil, nil, password.NewPasswordNil())
+
+			_ = tc.step(reader, state)
+
+			recorded := status.Recorded()
+			if len(recorded) < 1 {
+				t.Fatalf("expected a status update")
+			}
+
+			if recorded[0].Phase != tc.exp {
+				t.Errorf("first phase differs to expected (act:%d) (exp:%d)", int(recorded[0].Phase), int(tc.exp))
+			}
+
+			if recorded[0].DataGroup != 0 {
+				t.Errorf("expected no data-group for phase %d (act:%d)", int(tc.exp), recorded[0].DataGroup)
+			}
+		})
+	}
+}
+
+// verifies that PACE and BAC report the access-control phase they perform
+func TestAccessControlStepsReportPhase(t *testing.T) {
+	var err error
+
+	// valid CardAccess from SG passport, indicating PACE is supported
+	var cardAccess *document.CardAccess
+	cardAccess, err = document.NewCardAccess(utils.HexToBytes("31143012060A04007F0007020204020402010202010D"))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	tests := []struct {
+		name string
+		step ReaderStep
+		exp  StatusPhase
+	}{
+		{"performPace", performPace, STATUS_PHASE_ACCESS_CONTROL_PACE},
+		{"performBac", performBac, STATUS_PHASE_ACCESS_CONTROL_BAC},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var pass *password.Password
+			pass, err = password.NewPasswordMrzi("123456", "100101", "301225")
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			var status MockStatus
+			// 6FFF: card dead - the protocol fails, but the phase is reported before it starts
+			var nfc *iso7816.NfcSession = iso7816.NewNfcSession(&iso7816.StaticTransceiver{RApdu: utils.HexToBytes("6FFF")})
+			var reader *Reader = NewReader(&status, nfc, EmptyCscaTrustStore(t))
+			var state *ReaderState = NewReaderState(nil, nil, pass)
+
+			state.docEx.Document.Mf.CardAccess = cardAccess
+
+			if err = tc.step(reader, state); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			exp := []Status{{Phase: tc.exp}}
+			if act := status.Recorded(); !reflect.DeepEqual(act, exp) {
+				t.Errorf("recorded statuses differ to expected (act:%v) (exp:%v)", act, exp)
+			}
+		})
+	}
+}
+
+// verifies that a data-group read identifies WHICH data-group is being read,
+// which is what the free-text status could only express as English prose
+func TestReadLDS1DgsReportsDataGroup(t *testing.T) {
+	var status MockStatus
+	// 6A82: file not found - the data-groups are reported, then skipped
+	var nfc *iso7816.NfcSession = iso7816.NewNfcSession(&iso7816.StaticTransceiver{RApdu: utils.HexToBytes("6A82")})
+	var reader *Reader = NewReader(&status, nfc, EmptyCscaTrustStore(t))
+	var state *ReaderState = NewReaderState(nil, nil, password.NewPasswordNil())
+
+	state.docEx.Document.Mf.Lds1.Sod = &document.SOD{
+		LdsSecurityObject: &document.LDSSecurityObject{
+			DataGroupHashValues: []document.DataGroupHash{
+				{DataGroupNumber: 1},
+				{DataGroupNumber: 2},
+				{DataGroupNumber: 3}, // no file-id, so never read and never reported
+				{DataGroupNumber: 14},
+			},
+		},
+	}
+
+	if err := readLDS1dgs(reader, state); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	exp := []Status{
+		{Phase: STATUS_PHASE_READING_DATA_GROUP, DataGroup: 1},
+		{Phase: STATUS_PHASE_READING_DATA_GROUP, DataGroup: 2},
+		{Phase: STATUS_PHASE_READING_DATA_GROUP, DataGroup: 14},
+	}
+
+	if act := status.Recorded(); !reflect.DeepEqual(act, exp) {
+		t.Errorf("recorded statuses differ to expected (act:%v) (exp:%v)", act, exp)
+	}
+}
+
+func TestReadLDS1DgsSkipImagesReportsNoDataGroup(t *testing.T) {
+	var status MockStatus
+	var nfc *iso7816.NfcSession = iso7816.NewNfcSession(&PanicTransceiver{P: "no file reads expected when skipImages is set"})
+	var reader *Reader = NewReader(&status, nfc, EmptyCscaTrustStore(t))
+	var state *ReaderState = NewReaderState(nil, nil, password.NewPasswordNil())
+
+	state.docEx.Document.Mf.Lds1.Sod = &document.SOD{
+		LdsSecurityObject: &document.LDSSecurityObject{
+			DataGroupHashValues: []document.DataGroupHash{
+				{DataGroupNumber: 2},
+				{DataGroupNumber: 7},
+			},
+		},
+	}
+
+	reader.SkipImages()
+
+	if err := readLDS1dgs(reader, state); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if act := status.Recorded(); len(act) != 0 {
+		t.Errorf("expected no status updates for skipped data-groups (act:%v)", act)
+	}
+}
+
+// singleFileTransceiver serves one EF from memory: SELECT succeeds for the MF, the
+// MRTD AID and that one file-id, READ BINARY returns slices of its contents, and
+// every other file is reported as not found. Enough for a read to run all of its
+// steps without a card.
+type singleFileTransceiver struct {
+	fileId   uint16
+	fileData []byte
+	selected bool
+}
+
+var _ iso7816.Transceiver = (*singleFileTransceiver)(nil)
+
+func (transceiver *singleFileTransceiver) Transceive(_ int, ins int, p1 int, p2 int, data []byte, le int, _ []byte) []byte {
+	const rApduSuccess = "9000"
+	const rApduFileNotFound = "6A82"
+	const rApduNotSupported = "6D00"
+
+	switch {
+	case ins == int(iso7816.INS_SELECT) && p1 == 0x02: // select EF
+		transceiver.selected = bytes.Equal(data, utils.UInt16ToBytes(transceiver.fileId))
+		if !transceiver.selected {
+			return utils.HexToBytes(rApduFileNotFound)
+		}
+		return utils.HexToBytes(rApduSuccess)
+
+	case ins == int(iso7816.INS_SELECT): // select MF / AID
+		return utils.HexToBytes(rApduSuccess)
+
+	case ins == int(iso7816.INS_READ_BINARY):
+		if !transceiver.selected {
+			return utils.HexToBytes(rApduFileNotFound)
+		}
+
+		offset := (p1 * 256) + p2
+		if offset > len(transceiver.fileData) {
+			return utils.HexToBytes(rApduFileNotFound)
+		}
+
+		end := min(offset+le, len(transceiver.fileData))
+
+		return append(transceiver.fileData[offset:end:end], utils.HexToBytes(rApduSuccess)...)
+	}
+
+	// anything else (e.g. the BAC/PACE commands) is reported as unsupported
+	return utils.HexToBytes(rApduNotSupported)
+}
+
+// verifies the phases a complete read reports, in order, including the data-group
+// numbers and the final completion phase
+func TestReadDocumentReportsPhases(t *testing.T) {
+	// the sample document's SOD carries hashes for DG1, DG2, DG3, DG11, DG12 and
+	// DG14 - DG3 has no file-id, so it is never read and never reported
+	sampleDoc, err := document.SampleDocument()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	var status MockStatus
+	transceiver := &singleFileTransceiver{fileId: MRTDFileIdEFSOD, fileData: sampleDoc.Mf.Lds1.Sod.RawData}
+	var nfc *iso7816.NfcSession = iso7816.NewNfcSession(transceiver)
+	var reader *Reader = NewReader(&status, nfc, EmptyCscaTrustStore(t))
+
+	pass, err := password.NewPasswordMrzi("123456", "100101", "301225")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if _, _, err = reader.ReadDocument(pass, nil, nil); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	exp := []Status{
+		{Phase: STATUS_PHASE_CONNECTING},
+		{Phase: STATUS_PHASE_READING_CARD_ACCESS},
+		{Phase: STATUS_PHASE_ACCESS_CONTROL_PACE},
+		{Phase: STATUS_PHASE_ACCESS_CONTROL_BAC},
+		{Phase: STATUS_PHASE_READING_DIR},
+		{Phase: STATUS_PHASE_READING_SECURITY_OBJECT},
+		{Phase: STATUS_PHASE_READING_COMMON_DATA},
+		{Phase: STATUS_PHASE_READING_DATA_GROUP, DataGroup: 1},
+		{Phase: STATUS_PHASE_READING_DATA_GROUP, DataGroup: 2},
+		{Phase: STATUS_PHASE_READING_DATA_GROUP, DataGroup: 11},
+		{Phase: STATUS_PHASE_READING_DATA_GROUP, DataGroup: 12},
+		{Phase: STATUS_PHASE_READING_DATA_GROUP, DataGroup: 14},
+		{Phase: STATUS_PHASE_ACTIVE_AUTHENTICATION},
+		{Phase: STATUS_PHASE_CHIP_AUTHENTICATION},
+		{Phase: STATUS_PHASE_VERIFYING_DOCUMENT},
+		{Phase: STATUS_PHASE_PASSIVE_AUTHENTICATION},
+		{Phase: STATUS_PHASE_FINISHED},
+	}
+
+	if act := status.Recorded(); !reflect.DeepEqual(act, exp) {
+		t.Errorf("recorded statuses differ to expected (act:%v) (exp:%v)", act, exp)
+	}
+}
+
+// a read that fails does not report completion
+func TestReadDocumentFailureReportsNoFinishedPhase(t *testing.T) {
+	var status MockStatus
+	// 6FFF: card dead - the read fails on the first APDU
+	var nfc *iso7816.NfcSession = iso7816.NewNfcSession(&iso7816.StaticTransceiver{RApdu: utils.HexToBytes("6FFF")})
+	var reader *Reader = NewReader(&status, nfc, EmptyCscaTrustStore(t))
+
+	if _, _, err := reader.ReadDocument(password.NewPasswordNil(), nil, nil); err == nil {
+		t.Fatalf("expected error")
+	}
+
+	exp := []Status{{Phase: STATUS_PHASE_CONNECTING}}
+	if act := status.Recorded(); !reflect.DeepEqual(act, exp) {
+		t.Errorf("recorded statuses differ to expected (act:%v) (exp:%v)", act, exp)
+	}
+}

--- a/reader/status_test.go
+++ b/reader/status_test.go
@@ -326,3 +326,24 @@ func TestReadDocumentFailureReportsNoFinishedPhase(t *testing.T) {
 		t.Errorf("recorded statuses differ to expected (act:%v) (exp:%v)", act, exp)
 	}
 }
+
+// a nil ReaderStatus must not panic: the first phase is now reported by the very
+// first read step, so a caller that passes nil would otherwise lose the real error
+func TestReadDocumentNilStatusReportsRealError(t *testing.T) {
+	// 6FFF: card dead - the read fails on the first APDU
+	var nfc *iso7816.NfcSession = iso7816.NewNfcSession(&iso7816.StaticTransceiver{RApdu: utils.HexToBytes("6FFF")})
+	var reader *Reader = NewReader(nil, nfc, EmptyCscaTrustStore(t))
+
+	_, _, err := reader.ReadDocument(password.NewPasswordNil(), nil, nil)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	if strings.Contains(err.Error(), "nil pointer") {
+		t.Errorf("nil ReaderStatus masked the read error (act:%s)", err)
+	}
+
+	if !strings.Contains(err.Error(), "SelectMF") {
+		t.Errorf("expected the SelectMF failure to be reported (act:%s)", err)
+	}
+}


### PR DESCRIPTION
## Background

We maintain [Yivi](https://yivi.app). Reading the chip in passports and eID documents is part of our service offering, and today our mobile apps do that through **VCMRTD**, our own Dart MRTD reader.

We're now exploring whether we can **replace VCMRTD with `gmrtd/gmrtd`** as the reading engine in our mobile apps, driving the Go library through gomobile bindings behind our existing Dart UI. GMRTD covers more of the ICAO 9303 stack, is actively maintained, also by us, and would let us stop carrying a second full MRTD implementation. This PR is the first piece of feedback from that integration work: something we needed to make GMRTD fit a mobile reader, that we think is generally useful rather than specific to us.

## Why this change

`gmrtd/gmrtd` reports read progress through a single free-text string:

```go
type ReaderStatus interface {
	Status(msg string)
}
```

A host application driving a progress UI has to match English prose (`"Reading EF.SOD"`, `"Reading DG02"`, `"Chip Authentication (AA/CA)"`) to know what phase the read is in. That breaks on any wording change, can't be localised, and gives the host no structured handle on *which* data-group is being read. VCMRTD already exposes a typed reader state-machine to its UI, so matching that shape is what a drop-in replacement needs.

We solved this in our fork ([privacybydesign/gmrtd#2](https://github.com/privacybydesign/gmrtd/pull/2)) and would rather offer it upstream than carry a permanent divergence.

## What we want to achieve

Give hosts a **typed, stable progress contract** while keeping the human-readable strings for logging.

`ReaderStatus.Status` takes a `reader.Status` instead of a string:

```go
type Status struct {
	Phase     StatusPhase
	DataGroup int // 1..16, only set for STATUS_PHASE_READING_DATA_GROUP
}
```

The phases name every step the engine owns: connecting, reading EF.CardAccess, access control (PACE / BAC reported separately), reading EF.DIR, EF.SOD and EF.COM, reading a data-group, active and chip authentication, document verification, passive authentication, and completion.

Two deliberate refinements over the old strings:

- **PACE and BAC stay distinct** rather than collapsing into one "authenticating" state.
- **Active and chip authentication report separately.** They shared one status (`"Chip Authentication (AA/CA)"`) before, even though the engine runs them as two steps.

`Status.String()` returns the old English text, so logging and any existing string-based consumer keep working.

## Compatibility

This is a **breaking change** to the `ReaderStatus` interface (`Status(string)` → `Status(reader.Status)`), so it's marked `feat(reader)!`. The mobile facade passes phase and data-group as plain `int`s, because gomobile binds neither a named integer type nor constants declared with one — a typed phase silently drops from the generated Java/Objective-C. Phase values are pinned by a test so they stay a stable contract once a host builds against them.

## Tests

New coverage asserts the full phase sequence across a complete read (including `DG1, DG2, DG11, DG12, DG14` and `STATUS_PHASE_FINISHED`), that each step reports its own phase, that a data-group read identifies which data-group, and that the values survive the mobile facade.
