### PR TITLE
ci: guard gmrtd-ios notify step to run only on gmrtd/gmrtd

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -102,6 +102,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Notify gmrtd-ios
+        if: github.repository == 'gmrtd/gmrtd'
         env:
           GH_TOKEN: ${{ secrets.GMRTD_IOS_DISPATCH_TOKEN }}
           TAG: ${{ needs.release.outputs.tag_name }}


### PR DESCRIPTION
## Summary
- The `release-please.yml` workflow's `Notify gmrtd-ios` step dispatches a repository_dispatch event to `gmrtd/gmrtd-ios` on every tagged release.
- The rest of the release pipeline (release-please, iOS/Android builds, asset upload) is push-triggered on `main` and is already scoped correctly by GitHub's per-repo Actions isolation, so this only adds a belt-and-braces guard on the one step that reaches into another repo.
- Adds `if: github.repository == 'gmrtd/gmrtd'` to the `Notify gmrtd-ios` step so it only runs in the canonical repo, not on a fork's copy of the workflow.

## Test plan
- [ ] Confirm workflow YAML is valid (CI lint/parse on this PR)
- [ ] No behavior change expected for `gmrtd/gmrtd` releases