### PR TITLE
fix(activeauth): try all ICAO-permitted hashes for ECDSA AA

### DIFF
--- a/activeauth/active_auth.go
+++ b/activeauth/active_auth.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/big"
+	"strings"
 
 	cms "github.com/gmrtd/gmrtd/cms"
 	"github.com/gmrtd/gmrtd/cryptoutils"
@@ -342,36 +343,45 @@ func ValidateActiveAuthSignature(dg15 *document.DG15, intAuthRspBytes, rndIfd []
 				Y:     ecPoint.Y,
 			}
 
-			var alg = cryptoutils.CryptoHashFromEcPubKey(pub)
-			var hash = cryptoutils.CryptoHash(alg, rndIfd)
+			// Parse the signature once in each supported encoding. ICAO 9303
+			// specifies plain r||s (TR-03111, used by most passports); some
+			// national ID cards (e.g. the Portuguese Cartão de Cidadão) use
+			// ASN.1/DER (X9.62), which starts with a 0x30 SEQUENCE tag.
+			plainSig, plainErr := parseEcdsaSignaturePlain(intAuthRspBytes)
+			var derSig *EcdsaSignature
+			if len(intAuthRspBytes) > 0 && intAuthRspBytes[0] == 0x30 {
+				derSig, _ = parseEcdsaSignatureDER(intAuthRspBytes)
+			}
 
-			// Try plain r||s format first (TR-03110, used by most passports)
-			sig, plainErr := parseEcdsaSignaturePlain(intAuthRspBytes)
-			if plainErr == nil {
-				slog.Debug("ValidateActiveAuthSignature", "format", "plain r||s")
-				if ecdsa.Verify(pub, hash, sig.R, sig.S) {
-					// Success with plain format
+			// The exact hash algorithm is only signalled via DG14's
+			// ActiveAuthenticationInfo. When that is absent the verifier cannot
+			// know it in advance, so try each ICAO-permitted hash for the curve
+			// (curve-matched default first). This lets cards that sign with a
+			// hash shorter than the curve (e.g. a P-384 key signed with SHA-256,
+			// as the Portuguese Cartão de Cidadão does) verify.
+			candidateHashes := cryptoutils.CandidateAaHashes(pub)
+
+			for _, alg := range candidateHashes {
+				hash := cryptoutils.CryptoHash(alg, rndIfd)
+
+				if plainErr == nil && ecdsa.Verify(pub, hash, plainSig.R, plainSig.S) {
+					slog.Debug("ValidateActiveAuthSignature", "format", "plain r||s", "hashAlg", alg.String())
+					result.Success = true
+					return result, nil
+				}
+				if derSig != nil && ecdsa.Verify(pub, hash, derSig.R, derSig.S) {
+					slog.Debug("ValidateActiveAuthSignature", "format", "DER/ASN.1", "hashAlg", alg.String())
 					result.Success = true
 					return result, nil
 				}
 			}
 
-			// If plain format failed or didn't verify, and signature starts with 0x30, try DER format
-			if len(intAuthRspBytes) > 0 && intAuthRspBytes[0] == 0x30 {
-				slog.Debug("ValidateActiveAuthSignature", "format", "trying DER/ASN.1 fallback")
-				sig, derErr := parseEcdsaSignatureDER(intAuthRspBytes)
-				if derErr == nil {
-					if ecdsa.Verify(pub, hash, sig.R, sig.S) {
-						// Success with DER format
-						slog.Debug("ValidateActiveAuthSignature", "format", "DER/ASN.1 succeeded")
-						result.Success = true
-						return result, nil
-					}
-				}
+			// No permitted hash / encoding combination verified.
+			triedHashes := make([]string, len(candidateHashes))
+			for i, alg := range candidateHashes {
+				triedHashes[i] = alg.String()
 			}
-
-			// Both formats failed
-			return result, fmt.Errorf("(ValidateActiveAuthSignature) AA signature did not verify with hash: %s for the provided nonce (tried plain r||s and DER formats)", alg.String())
+			return result, fmt.Errorf("(ValidateActiveAuthSignature) AA signature did not verify for the provided nonce (tried hashes: %s; formats: plain r||s and DER)", strings.Join(triedHashes, ", "))
 		}
 	default:
 		return result, fmt.Errorf("(ValidateActiveAuthSignature) unsupported SubjectPublicKeyInfo (OID:%s) (Context:%s)", subPubKeyInfo.Algorithm.Algorithm.String(), errContext)

--- a/activeauth/active_auth_test.go
+++ b/activeauth/active_auth_test.go
@@ -711,6 +711,63 @@ func TestEcdsaValidateActiveAuthSignatureDERFormat(t *testing.T) {
 	}
 }
 
+// TestEcdsaValidateActiveAuthSignatureShorterHash verifies that AA succeeds when
+// the chip signs the nonce with a hash that is *shorter* than the curve-matched
+// default. ICAO 9303 (6.1.2.3) permits any hash whose output length is <= the key
+// length, and the exact hash is only signalled via DG14.ActiveAuthenticationInfo.
+// Cards that omit DG14 (e.g. the Portuguese Cartão de Cidadão: a P-384 AA key
+// signed with SHA-256) previously failed because only the curve-matched hash
+// (SHA-384) was tried. See privacybydesign/gmrtd (Portugal ID card AA regression).
+func TestEcdsaValidateActiveAuthSignatureShorterHash(t *testing.T) {
+	// P-384 key, but signed with SHA-256 (shorter than the curve-matched SHA-384)
+	priv, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+
+	dg15bytes, err := makeDG15FromECPublicKey(&priv.PublicKey)
+	if err != nil {
+		t.Fatalf("DG15 build: %v", err)
+	}
+
+	rndIfd := cryptoutils.RandomBytes(8)
+	hash := cryptoutils.CryptoHash(crypto.SHA256, rndIfd) // deliberately NOT the curve-matched SHA-384
+
+	r, s, err := ecdsa.Sign(rand.Reader, priv, hash)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	plainSig := concatRSFixed(elliptic.P384(), r, s)
+	derSig, err := encodeDERSignature(r, s)
+	if err != nil {
+		t.Fatalf("DER encode: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		sig  []byte
+	}{
+		{"plain r||s", plainSig},
+		{"DER", derSig},
+	}
+
+	for _, tc := range cases {
+		dg15, err := document.NewDG15(dg15bytes)
+		if err != nil {
+			t.Fatalf("%s: NewDG15 error: %v", tc.name, err)
+		}
+
+		aaResult, err := ValidateActiveAuthSignature(dg15, tc.sig, rndIfd)
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+		}
+		if aaResult == nil || !aaResult.Success {
+			t.Errorf("%s: expected AA success with shorter hash (SHA-256 on P-384 key)", tc.name)
+		}
+	}
+}
+
 // TestParseEcdsaSignaturePlain tests the parseEcdsaSignaturePlain function
 func TestParseEcdsaSignaturePlain(t *testing.T) {
 	curve := elliptic.P256()

--- a/cryptoutils/crypto_utils.go
+++ b/cryptoutils/crypto_utils.go
@@ -350,6 +350,41 @@ func CryptoHashFromEcPubKey(pub *ecdsa.PublicKey) crypto.Hash {
 	}
 }
 
+// CandidateAaHashes returns the hash algorithms permitted by ICAO 9303 for
+// ECDSA Active Authentication with the given public key, ordered by preference
+// (most likely first).
+//
+// ICAO 9303 (6.1.2.3) permits a hash whose output length is the same as, or
+// shorter than, the length of the ECDSA key, restricted to SHA-224, SHA-256,
+// SHA-384 and SHA-512. Which one a chip actually uses is only signalled via
+// DG14's ActiveAuthenticationInfo; when that is absent (e.g. the Portuguese
+// Cartão de Cidadão, which carries no DG14) the verifier cannot know the hash
+// in advance and must try each permitted algorithm. The curve-matched default
+// (see CryptoHashFromEcPubKey) is returned first so the common case still
+// verifies on the first attempt, followed by the remaining permitted hashes
+// from strongest to weakest.
+func CandidateAaHashes(pub *ecdsa.PublicKey) []crypto.Hash {
+	keyBits := pub.Params().N.BitLen()
+
+	// curve-matched default first (preserves prior behaviour for the common case)
+	preferred := CryptoHashFromEcPubKey(pub)
+	candidates := []crypto.Hash{preferred}
+
+	// then any other ICAO-permitted hash (output length <= key length),
+	// strongest first, so cards that sign with a hash shorter than the curve
+	// (e.g. a P-384 key signed with SHA-256) still verify.
+	for _, h := range []crypto.Hash{crypto.SHA512, crypto.SHA384, crypto.SHA256, crypto.SHA224} {
+		if h == preferred {
+			continue
+		}
+		if CryptoHashDigestSize(h)*8 <= keyBits {
+			candidates = append(candidates, h)
+		}
+	}
+
+	return candidates
+}
+
 // support for P192 (secp-192r1) which is required by some countries but not supported by the go libraries
 func EllipticP192() elliptic.Curve {
 	var curveParams *elliptic.CurveParams = &elliptic.CurveParams{

--- a/cryptoutils/crypto_utils_test.go
+++ b/cryptoutils/crypto_utils_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/elliptic"
 	"encoding/asn1"
 	"math/big"
+	"reflect"
 	"testing"
 
 	"github.com/gmrtd/gmrtd/oid"
@@ -835,6 +836,28 @@ func TestCryptoHashFromEcPubKey(t *testing.T) {
 		pub := &ecdsa.PublicKey{Curve: tc.curve, X: tc.curve.Params().Gx, Y: tc.curve.Params().Gy}
 		got := CryptoHashFromEcPubKey(pub)
 		if got != tc.want {
+			t.Errorf("curve %s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestCandidateAaHashes(t *testing.T) {
+	cases := []struct {
+		name  string
+		curve elliptic.Curve
+		want  []crypto.Hash
+	}{
+		// curve-matched default first, then other ICAO-permitted hashes
+		// (output length <= key length) from strongest to weakest.
+		{"P-224", elliptic.P224(), []crypto.Hash{crypto.SHA224}},
+		{"P-256", elliptic.P256(), []crypto.Hash{crypto.SHA256, crypto.SHA224}},
+		{"P-384", elliptic.P384(), []crypto.Hash{crypto.SHA384, crypto.SHA256, crypto.SHA224}},
+		{"P-521", elliptic.P521(), []crypto.Hash{crypto.SHA512, crypto.SHA384, crypto.SHA256, crypto.SHA224}},
+	}
+	for _, tc := range cases {
+		pub := &ecdsa.PublicKey{Curve: tc.curve, X: tc.curve.Params().Gx, Y: tc.curve.Params().Gy}
+		got := CandidateAaHashes(pub)
+		if !reflect.DeepEqual(got, tc.want) {
 			t.Errorf("curve %s: got %v, want %v", tc.name, got, tc.want)
 		}
 	}


### PR DESCRIPTION
## Problem

Active Authentication fails for the Portuguese *Cartão de Cidadão* / ID card, even though the card reads fine and Passive Authentication succeeds:

```
(ValidateActiveAuthSignature) AA signature did not verify with hash: SHA-384
for the provided nonce (tried plain r||s and DER formats)
```

The AA public key in **DG15 is a P-384 key**, but the chip signs the nonce with **SHA-256**. The EC branch of `ValidateActiveAuthSignature` derived the hash algorithm solely from the curve size (`CryptoHashFromEcPubKey`: P-384 → SHA-384) and tried **only** that one hash, so verification never succeeded.

ICAO 9303 §6.1.2.3 permits any hash whose output length is `<=` the ECDSA key length (SHA-224/256/384/512). The exact hash is only signalled via `DG14.ActiveAuthenticationInfo`, and this card carries **no DG14** (data groups `[DG1 DG11 DG15 DG2]`), so the verifier must try each permitted hash.

> 6.1.2.3 ECDSA
> For ECDSA, the plain signature format according to [TR-03111] SHALL be used. Only prime curves with uncompressed points SHALL be used. A hash algorithm, whose output length is of the same length or shorter than the length of the ECDSA key in use, SHALL be used. Only SHA-224, SHA-256, SHA-384 or SHA-512 are supported as hash functions.
> RIPEMD-160 and SHA-1 SHALL NOT be used.
>
> The message M to be signed is the nonce RND.IFD provided by the Inspection System.

## Change

- Add `cryptoutils.CandidateAaHashes(pub)` — returns the ICAO-permitted hashes for the curve, curve-matched default first (so the common case still verifies on the first attempt), then the remaining permitted hashes strongest → weakest.
- Rewrite the EC branch of `ValidateActiveAuthSignature` to parse the signature once in each supported encoding (plain `r||s` and DER) and iterate over the candidate hashes × both encodings.

## Security

Passive Authentication already binds DG15 to a trusted CSCA chain, so trying additional ICAO-permitted hashes does not weaken AA — it still verifies possession of the private key matching the genuine DG15 public key with the session nonce.

## Tests

- `TestEcdsaValidateActiveAuthSignatureShorterHash` — P-384 key signed with SHA-256 (reproduces the Portuguese card); fails without this change, passes with it, in both plain and DER encodings.
- `TestCandidateAaHashes` — unit coverage of the permitted-hash ordering for P-224/256/384/521.
- Full `activeauth` and `cryptoutils` suites pass, plus `go build ./...` and `go vet`.
- **Validated against a real Portuguese *Cartão de Cidadão* ID card**: with this change, Active Authentication succeeds end-to-end on the physical card that previously failed.

---

This change was developed and merged on our fork ([privacybydesign/gmrtd#4](https://github.com/privacybydesign/gmrtd/pull/4)) against real Portuguese ID card hardware, and is contributed back here rebased onto current `main`.

